### PR TITLE
Fix intermittend connection error to mongo

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,12 +7,18 @@ services:
       - "8080:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+  mongodb_seed:
+    image: bitnami/mongodb:4.2
+    volumes:
+      - "./seed_db/seed:/seed"
+      - "./seed_db/mongo_import.sh:/docker-entrypoint-initdb.d/mongo_import.sh"
+    depends_on:
+      - mongodb
+    restart: on-failure
   mongodb:
     image: bitnami/mongodb:4.2
     volumes:
       - "mongodb_data:/bitnami"
-      - "./seed_db/seed:/seed"
-      - "./seed_db/mongo_import.sh:/docker-entrypoint-initdb.d/mongo_import.sh"
   catamel:
     image: dacat/catamel:latest
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,12 @@ services:
     image: bitnami/mongodb:4.2
     volumes:
       - "./seed_db/seed:/seed"
-      - "./seed_db/mongo_import.sh:/docker-entrypoint-initdb.d/mongo_import.sh"
+      - "./seed_db/mongo_import.sh:/seed/mongo_import.sh"
+    command: 
+      - "sh"
+      - "-c"
+      - "chmod u+x /seed/mongo_import.sh && /seed/mongo_import.sh"
+    user: "1000:1000"
     depends_on:
       - mongodb
     restart: on-failure

--- a/seed_db/mongo_import.sh
+++ b/seed_db/mongo_import.sh
@@ -4,5 +4,5 @@ cd /seed
 
 for FILE_NAME in $(ls *.json)
 do
-    mongoimport --db dacat --collection ${FILE_NAME%.*} --file $FILE_NAME --jsonArray
+    mongoimport --host mongodb --db dacat --collection ${FILE_NAME%.*} --file $FILE_NAME --jsonArray
 done

--- a/seed_db/mongo_import.sh
+++ b/seed_db/mongo_import.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 cd /seed
 


### PR DESCRIPTION
Before: When seeding mongo, the container first loads the datasets and then
restarts mongo. This might cause problems, as during the restart the
connection from catamel to mongo can be established, resulting in an
error. Now: this solution loads the db once it is up, avoiding the restart