### PR TITLE
swagger ui forwarding fix

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       - ./config/backend/config.env:/home/node/app/.env
       - ./config/backend/functionalAccounts.json:/home/node/app/functionalAccounts.json
     labels:
-      - "traefik.http.routers.backend.rule=PathPrefix(`/api`, `/auth`, `/explorer-next`)"
+      - "traefik.http.routers.backend.rule=PathPrefix(`/api`, `/auth`, `/explorer`)"
       - "traefik.http.routers.backend.entrypoints=web"
   frontend:
     # ghcr.io/scicatproject/frontend:latest


### PR DESCRIPTION
This pull request fixes a one line issue within the docker-compose.yaml that prevents the user from accessing the swagger UI