### PR TITLE
add archival mock service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,12 +66,12 @@ services:
       backend:
         condition: service_started
     environment:
-      - "SCI_URL=http://backend:3000/api/v3/"
-      - "SCI_USER=admin"
-      - "SCI_PW=2jf70TPNZsS" 
-      - "RMQ_URL=rabbitmq"
-      - "RMQ_USER=guest"
-      - "RMQ_PW=guest"
+      SCI_URL: "http://backend:3000/api/v3/"
+      SCI_USER: "admin"
+      SCI_PW: "2jf70TPNZsS" 
+      RMQ_URL: "rabbitmq"
+      RMQ_USER: "guest"
+      RMQ_PW: "guest"
 volumes:
   mongodb_data:
     driver: local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -58,6 +58,20 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
+  archive-mock:
+    build: https://github.com/SwissOpenEM/ScicatArchiveMock.git
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      backend:
+        condition: service_started
+    environment:
+      - "SCI_URL=http://backend:3000/api/v3/"
+      - "SCI_USER=admin"
+      - "SCI_PW=2jf70TPNZsS" 
+      - "RMQ_URL=rabbitmq"
+      - "RMQ_USER=guest"
+      - "RMQ_PW=guest"
 volumes:
   mongodb_data:
     driver: local


### PR DESCRIPTION
# Archival Mock-Up Service

Adds an archival mock up service that will mark datasets as archived when an archival job is requested for them. 
Fixes #22 