### PR TITLE
Avoid running CI On push to master

### DIFF
--- a/.github/workflows/docker_compose_test.yaml
+++ b/.github/workflows/docker_compose_test.yaml
@@ -1,9 +1,6 @@
 name: Docker Compose CI
 
 on:  # yamllint disable-line rule:truthy
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Push to master is blocked anyway. This prevents the CI to run twice when PR is opened and merged