### PR TITLE
Allow selection of BE through env var

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+BE_VERSION=backend

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,8 @@
 version: '3'
 include:
   - ./services/mongodb/docker-compose.yaml
-  - ./services/rabbitmq/docker-compose.yaml
   - ./services/backend/docker-compose.yaml
   - ./services/backendnext/docker-compose.yaml
   - ./services/frontend/docker-compose.yaml
   - ./services/searchapi/docker-compose.yaml
-  - ./services/archivemock/docker-compose.yaml
   - ./services/proxy/docker-compose.yaml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,7 @@
 version: '3'
 include:
   - ./services/mongodb/docker-compose.yaml
-  - ./services/backend/docker-compose.yaml
-  - ./services/backendnext/docker-compose.yaml
+  - ./services/${BE_VERSION:-backendnext}/docker-compose.yaml
   - ./services/frontend/docker-compose.yaml
   - ./services/searchapi/docker-compose.yaml
   - ./services/proxy/docker-compose.yaml

--- a/services/backend/docker-compose.yaml
+++ b/services/backend/docker-compose.yaml
@@ -1,3 +1,7 @@
+include:
+  - ../rabbitmq/docker-compose.yaml
+  - ../archivemock/docker-compose.yaml
+
 services:
   backend:
     image: ghcr.io/scicatproject/backend:latest

--- a/services/backendnext/docker-compose.yaml
+++ b/services/backendnext/docker-compose.yaml
@@ -1,5 +1,5 @@
 services:
-  backendnext:
+  backend:
     image: ghcr.io/scicatproject/backend-next:v4.4.0
     depends_on:
       - mongodb
@@ -8,7 +8,7 @@ services:
     env_file:
       - ./config/.env
     labels:
-      - traefik.http.routers.backendnext.rule=Host(`backendnext.localhost`)
+      - traefik.http.routers.backend.rule=Host(`backend.localhost`)
     healthcheck:
       test: wget --spider -Y off 'http://127.0.0.1:3000/api/v3/health'
       start_period: 5s

--- a/services/frontend/config/config.base.json
+++ b/services/frontend/config/config.base.json
@@ -1,5 +1,5 @@
 {
-   "accessTokenPrefix": "",
+   "accessTokenPrefix": "Bearer ",
    "addDatasetEnabled":false,
    "archiveWorkflowEnabled":false,
    "datasetReduceEnabled":true,
@@ -17,7 +17,7 @@
    "jsonMetadataEnabled":true,
    "jupyterHubUrl":"",
    "landingPage":"",
-   "lbBaseURL":"http://backend.localhost",
+   "lbBaseURL":"http://backendnext.localhost",
    "localColumns":[
       {
          "name":"datasetName",

--- a/services/frontend/config/config.base.json
+++ b/services/frontend/config/config.base.json
@@ -17,7 +17,7 @@
    "jsonMetadataEnabled":true,
    "jupyterHubUrl":"",
    "landingPage":"",
-   "lbBaseURL":"http://backendnext.localhost",
+   "lbBaseURL":"http://backend.localhost",
    "localColumns":[
       {
          "name":"datasetName",

--- a/services/frontend/config/config.v3.json
+++ b/services/frontend/config/config.v3.json
@@ -1,4 +1,3 @@
 {
-    "accessTokenPrefix": "",
-    "lbBaseURL": "http://backend.localhost"
+    "accessTokenPrefix": ""
 }

--- a/services/frontend/config/config.v3.json
+++ b/services/frontend/config/config.v3.json
@@ -1,0 +1,4 @@
+{
+    "accessTokenPrefix": "",
+    "lbBaseURL": "http://backend.localhost"
+}

--- a/services/frontend/config/init.sh
+++ b/services/frontend/config/init.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+apk update && apk add jq
+
+[[ $BE_VERSION = "backendnext" ]] && CONFIGS=`find /config -name *.json ! -name "config.v3.json" | sort` || CONFIGS=`ls /config/*.json`
+
+jq -s 'reduce .[] as $item ({}; . * $item)' $CONFIGS > /usr/share/nginx/html/assets/config.json

--- a/services/frontend/docker-compose.yaml
+++ b/services/frontend/docker-compose.yaml
@@ -5,6 +5,12 @@ services:
       backend:
         condition: service_healthy
     volumes:
-      - ./config/config.json:/usr/share/nginx/html/assets/config.json
+      - ./config:/config
+    command:
+      - sh
+      - -c
+      - /config/init.sh && nginx -g "daemon off;"
+    environment:
+      BE_VERSION: ${BE_VERSION:-backendnext}
     labels:
       - traefik.http.routers.frontend.rule=Host(`localhost`)

--- a/services/mongodb/config/init.js
+++ b/services/mongodb/config/init.js
@@ -1,4 +1,4 @@
-db = connect('mongodb://localhost/dacat');
+db = connect(`mongodb://localhost/${process.env.BE_VERSION === 'backendnext'? 'dacat-next': 'dacat'}`);
 seedFiles = fs.readdirSync('/seed');
 seedFiles.forEach((filename) => {
   collectionName = filename.replace(/\.json$/, '');

--- a/services/mongodb/docker-compose.yaml
+++ b/services/mongodb/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
       - mongodb_data:/data/db
       - ./config/init.js:/docker-entrypoint-initdb.d/init.js
       - ./config/seed:/seed
+    environment:
+      BE_VERSION: ${BE_VERSION:-backendnext}
 
 volumes:
   mongodb_data:


### PR DESCRIPTION
I started to have a look at this #107 and I think the PR here could work well. 

It is split into commits to ease the review, I will open dedicated PRs if this looks ok.

The idea is to enable only one backend at a time, which can be configured through an ENV var. Then the other containers will connect to it without noticing the change (also the code does not require much change).

This relies on an include rule which depends on the ENV provided and on the fact that both be_next and be expose a container named `backend`, which the others connect to. This might also simplify in the future the connection to the `archivemock`

I still have to update the README (both the global and the backend one) and the CI

The drawback of this is that it does not support running both BEs at the same time, but this can be circumvented (I think) in a later PR by making the traefik port custom and setting the docker compose `project-name`. In this way, one can run: 

```sh
docker-compose up -d 
```

which will run the services with the old BE

and then run, e.g.
```sh
export BE_VERSION=backendnext
export TRAEFIK_PORT=81
docker-compose -p $BE_VERSION up -d 
```

which will run the services with the new BE and expose them on port 81, ultimately creating 2 envs with all the services, one relying on the new BE and on port 81, another relying on the old BE and on port 80.
