### PR TITLE
use docker image for archive mock

### DIFF
--- a/services/archivemock/docker-compose.yaml
+++ b/services/archivemock/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   archivemock:
-    build: https://github.com/SwissOpenEM/ScicatArchiveMock.git
+    image: ghcr.io/scicatproject/archive-mock:v1.0.0
     depends_on:
       rabbitmq:
         condition: service_healthy


### PR DESCRIPTION
Closes #121 

 * The archive mock will now use the newly available image in the project repository