### PR TITLE
Don't run CI when only markdown files changed

### DIFF
--- a/.github/workflows/compose_test.yaml
+++ b/.github/workflows/compose_test.yaml
@@ -5,7 +5,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
     paths-ignore:
-      - '**/*.md'
+      - '**.md'
 jobs:
   yaml-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It previously didn't match the top-level `README.md`