### PR TITLE
Add mkdocs mike for versions

### DIFF
--- a/.github/mkdocs.yaml
+++ b/.github/mkdocs.yaml
@@ -2,11 +2,17 @@ site_name: SciCatLive
 docs_dir: ../docs
 theme:
   name: material
+  custom_dir: overrides
+
+extra:
+  version:
+    provider: mike
 
 plugins:
   - search
   - awesome-pages:
       collapse_single_pages: true
+  - mike
 
 markdown_extensions:
   - admonition

--- a/.github/overrides/main.html
+++ b/.github/overrides/main.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+<!-- prevent caching -->
+<meta http-equiv="cache-control" content="no-cache, must-revalidate, post-check=0, pre-check=0" />
+<meta http-equiv="cache-control" content="max-age=0" />
+<meta http-equiv="expires" content="0" />
+<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
+<meta http-equiv="pragma" content="no-cache" />
+
+{% block outdated %}
+  You're not viewing the latest released version.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Click here to go to latest release.</strong>
+  </a>
+{% endblock %}

--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -4,6 +4,8 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - main
+    tags:
+      - v*
 
 jobs:
   build:
@@ -19,7 +21,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-            pip install mkdocs mkdocs-material \
+            pip install mkdocs mkdocs-material mike \
                 mkdocs-awesome-pages-plugin beautifulsoup4 lxml
 
       - name: Copy all to docs folder
@@ -27,7 +29,26 @@ jobs:
           mkdir -p docs
           shopt -s extglob
           mv !(docs) docs/
-      - name: Build and Deploy
-        run: mkdocs gh-deploy --force --config-file .github/mkdocs.yaml
+
+      - name: Deploy documentation
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            TAG=${{ github.ref_name }}
+            VERSION=$(echo ${TAG} | awk -F'.' '{print $1"."$2}')
+          fi
+
+          export BASE_URL=${BASE_URL}/${TAG:-main}
+
+          git fetch origin ${DOCS_BRANCH} --depth=1
+          mike deploy -F ${DOCS_CONFIG} \
+            --push --branch ${DOCS_BRANCH} \
+            --update-aliases ${VERSION:-main} latest
+          mike set-default -F ${DOCS_CONFIG} \
+            --push --branch ${DOCS_BRANCH} latest
         env:
-          BASE_URL: https://github.com/SciCatProject/scicatlive/blob/main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_COMMITTER_NAME: ci-bot
+          GIT_COMMITTER_EMAIL: ci-bot@example.com
+          BASE_URL: https://github.com/SciCatProject/scicatlive/blob
+          DOCS_BRANCH: gh-pages
+          DOCS_CONFIG: .github/mkdocs.yaml


### PR DESCRIPTION
This PR adds the version selector to docs:
![image](https://github.com/user-attachments/assets/f65d6f12-c14f-4e54-a3cf-cc726acdcda0)

It also adds a deprecation warning and redirect for old versions

It also hardly remove cache to avoid having the wrong deprecation warning for the latest version

see the example [here](https://scicatproject.github.io/scicatlive/)