### PR TITLE
Bind node-jq version to latest working

### DIFF
--- a/services/backend/services/v3/entrypoints/merge_json.sh
+++ b/services/backend/services/v3/entrypoints/merge_json.sh
@@ -3,5 +3,5 @@
 for config in $(find /config -maxdepth 1 -type f -exec basename {} \; | cut -d '.' -f 1 | sort -u)
 do
     # shellcheck disable=SC2016
-    npx --yes node-jq -s 'reduce .[] as $item ({}; . * $item)' /config/"${config}"*.json > /home/node/app/server/"${config}".json
+    npx --yes node-jq@6.0.0 -s 'reduce .[] as $item ({}; . * $item)' /config/"${config}"*.json > /home/node/app/server/"${config}".json
 done


### PR DESCRIPTION
The latest version (6.0.1) is not compatible. This will probably be fixed once node-jq realises the bug