### PR TITLE
Avoid tagging main with latest

### DIFF
--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -42,7 +42,7 @@ jobs:
           git fetch origin ${DOCS_BRANCH} --depth=1
           mike deploy -F ${DOCS_CONFIG} \
             --push --branch ${DOCS_BRANCH} \
-            --update-aliases ${VERSION:-main} latest
+            --update-aliases ${VERSION:-main} ${VERSION:+latest}
           mike set-default -F ${DOCS_CONFIG} \
             --push --branch ${DOCS_BRANCH} latest
         env:


### PR DESCRIPTION
As pushes on main could be after the latest release, the HTML docs should always mark main as "non latest released"