### PR TITLE
Increase FE DEV retries

### DIFF
--- a/services/frontend/compose.dev.yaml
+++ b/services/frontend/compose.dev.yaml
@@ -18,6 +18,7 @@ services:
       - traefik.http.services.frontend.loadbalancer.server.port=4200
     healthcheck:
       test: pgrep -f "/bin/sh /usr/local/bin/infinite_loop.sh"
+      retries: 5
 
 volumes:
   frontend_dev:


### PR DESCRIPTION
Depending on the host resources, 3 retries (default) might not be enough