### PR TITLE
Remove platform constraints

### DIFF
--- a/services/backend/services/v4/compose.base.yaml
+++ b/services/backend/services/v4/compose.base.yaml
@@ -1,6 +1,5 @@
 services:
   backend:
-    platform: linux/amd64
     image: ghcr.io/scicatproject/backend-next:v4.6.6
     depends_on:
       mongodb:

--- a/services/backend/services/v4/compose.dev.yaml
+++ b/services/backend/services/v4/compose.dev.yaml
@@ -1,7 +1,6 @@
 services:
   backend:
     image: !reset null
-    platform: !reset null
     build:
       context: https://github.com/SciCatProject/scicat-backend-next.git
       target: dev

--- a/services/frontend/compose.base.yaml
+++ b/services/frontend/compose.base.yaml
@@ -1,6 +1,5 @@
 services:
   frontend:
-    platform: linux/amd64
     image: ghcr.io/scicatproject/frontend:v4.5.0
     depends_on:
       backend:


### PR DESCRIPTION
As supported by this [v4 relase](https://github.com/SciCatProject/scicat-backend-next/pkgs/container/backend-next/302018549?tag=v4.6.6), merged in scicatlive by this [PR](https://github.com/SciCatProject/scicatlive/pull/353), the platform constraint is now unnecessary

Relates to #145 