### PR TITLE
Install all depens in DEV and avoid binding dist

### DIFF
--- a/entrypoints/add_chrome.sh
+++ b/entrypoints/add_chrome.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-[ -e ".finished" ] && return 0
-
 apk update && apk add chromium

--- a/entrypoints/setup_git.sh
+++ b/entrypoints/setup_git.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 
+apk update && apk add git
+
 [ -e ".finished" ] && return 0
 
 ls .git && return 0
 
 echo "${GITHUB_REPO}" | grep -q "#" && TAG="${GITHUB_REPO#*#}" || TAG=
 
-apk update && apk add git
 git init
 chown -R "$(find . -maxdepth 1 -exec ls -ld {} + | awk '{print $3":"$4}' | tail -n1)" .git
 git config --global --add safe.directory "${PWD}"

--- a/services/compose.dev.yaml
+++ b/services/compose.dev.yaml
@@ -26,7 +26,6 @@ services:
       - ${DEV_VOLUME:-${APP}}_dev:${WORKDIR:-/home/node/app}
       - ${DEV_BBACKUP:+${PWD}/bbackup/${COMPOSE_PROJECT_NAME}/${DEV_VOLUME:-${APP}}:}/bbackup
       # These allow to keep changes from npm install/build from Dockerfile CMDs
-      - ${WORKDIR:-/home/node/app}/dist
       - ${WORKDIR:-/home/node/app}/node_modules
   node-app-from-remote:
     extends: node-app-from-local


### PR DESCRIPTION
This allows missing packages on container recreation and avoids `npm run build` buisy resources problems