### PR TITLE
Open draft PRs for v3 breaking changes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,7 +21,7 @@
     {
       "matchDatasources": ["docker"],
       "matchPackageNames": ["rabbitmq"],
-      "matchUpdateTypes": ["major", "minor", "patch"],
+      "matchUpdateTypes": ["major", "minor"],
       "labels": ["v3 breaking change"],
       "draftPR": true
     }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,20 @@
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/scicatproject/frontend"],
+      "matchUpdateTypes": ["major"],
+      "labels": ["v3 breaking change"],
+      "draftPR": true
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["rabbitmq"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "labels": ["v3 breaking change"],
+      "draftPR": true
     }
   ]
 }


### PR DESCRIPTION
Newer rabbitmq minor and new frontend major introduce breaking changes for V3. This PR tells renovate to open these PRs as drafts and adds a label to them