### PR TITLE
(landingpage) add config keys for status-banner and support-email

### DIFF
--- a/services/landingpage/README.md
+++ b/services/landingpage/README.md
@@ -14,8 +14,6 @@ In the default configuration [config.json file](./config/config.json), the landi
 
 For an explanation of how setting `BE_VERSION` changes the environment creation see [here](../../README.md#docker-compose-profiles-and-env-variables-configuration-options).
 
-You can also add a footer with customizable `contactEmail` and a status banner with `statusCode = INFO | WARN | NONE` and a corresponding `statusMessage` as shown in [config.json](./config/config.json). All of these three settings are optional. 
-
 ## Enable additional features
 
 Setting the [BACKEND_HTTPS_URL and FRONTEND_HTTPS_URL env variables](../../.env) requires changing the `backend` and the `frontend` URL used by the `landingpage`. This is managed [here](../../entrypoints/merge_json.sh).

--- a/services/landingpage/README.md
+++ b/services/landingpage/README.md
@@ -14,6 +14,8 @@ In the default configuration [config.json file](./config/config.json), the landi
 
 For an explanation of how setting `BE_VERSION` changes the environment creation see [here](../../README.md#docker-compose-profiles-and-env-variables-configuration-options).
 
+You can also add a footer with customizable `contactEmail` and a status banner with `statusCode = INFO | WARN | NONE` and a corresponding `statusMessage` as shown in [config.json](./config/config.json). All of these three settings are optional. 
+
 ## Enable additional features
 
 Setting the [BACKEND_HTTPS_URL and FRONTEND_HTTPS_URL env variables](../../.env) requires changing the `backend` and the `frontend` URL used by the `landingpage`. This is managed [here](../../entrypoints/merge_json.sh).

--- a/services/landingpage/config/config.json
+++ b/services/landingpage/config/config.json
@@ -3,5 +3,8 @@
     "doiBaseUrl": "http://landingpage.localhost/detail/",
     "facility": "facility",
     "scicatBaseUrl": "${FRONTEND_URL}",
-    "lbBaseUrl": "${BACKEND_URL}"
+    "lbBaseUrl": "${BACKEND_URL}",
+    "statusCode": "INFO",
+    "statusMessage": "This is a customizable status message",
+    "contactEmail": "support@scicat.eu"
 }


### PR DESCRIPTION
Added landing page settings for `statusMessage` (introduced in https://github.com/SciCatProject/LandingPageServer/pull/394) and `contactEmail` (introduced in https://github.com/SciCatProject/LandingPageServer/pull/396) to `config.json` and updated README.