### PR TITLE
Replace example DOI prefix by a valid one

### DIFF
--- a/services/backend/services/v3/README.md
+++ b/services/backend/services/v3/README.md
@@ -43,7 +43,7 @@ It allows setting backend-specific configurations. Here are the commonly changed
 Name | Description | Value
 --- | --- | ---
 pidPrefix | prefix of the internal IDs | "PID.SAMPLE.PREFIX"
-doiPrefix | prefix of the published DOIs | "DOI.SAMPLE.PREFIX"
+doiPrefix | prefix of the published DOIs | "10.9999"
 policyPublicationShiftInYears | number of years before the data should be made open access. This is only an annotation in the metadata and no action is triggered after expiration | 3
 policyRetentionShiftInYears | number of years by which the data should be kept. This is only an annotation in the metadata and no action is triggered after expiration | 10
 site | name of the facility runnin SciCat | "SAMPLE-SITE"

--- a/services/backend/services/v3/config/config.local.js
+++ b/services/backend/services/v3/config/config.local.js
@@ -7,7 +7,7 @@ module.exports = {
   host: process.env.HOST || "0.0.0.0",
   port: process.env.PORT || 3000,
   pidPrefix: "PID.SAMPLE.PREFIX",
-  doiPrefix: "DOI.SAMPLE.PREFIX",
+  doiPrefix: "10.9999",
   policyPublicationShiftInYears: 3,
   policyRetentionShiftInYears: 10,
   metadataKeysReturnLimit:100,

--- a/services/mongodb/config/seed/PublishedData.json
+++ b/services/mongodb/config/seed/PublishedData.json
@@ -1,6 +1,6 @@
 [
 	{
-		"_id": "DOI.SAMPLE.PREFIX/desy_pub1",
+		"_id": "10.9999/desy_pub1",
 		"creator": [
 			"Oleksandr Yefanov",
 			"al."
@@ -39,7 +39,7 @@
 		}
 	},
 	{
-		"_id": "DOI.SAMPLE.PREFIX/dls_pub1",
+		"_id": "10.9999/dls_pub1",
 		"creator": [
 			"Stephen Collins"
 		],
@@ -75,7 +75,7 @@
 		}
 	},
 	{
-		"_id": "DOI.SAMPLE.PREFIX/hzdr_pub1",
+		"_id": "10.9999/hzdr_pub1",
 		"creator": [
 			"Hao Chu",
 			"al."
@@ -112,7 +112,7 @@
 		}
 	},
 	{
-		"_id": "DOI.SAMPLE.PREFIX/maxiv_pub1",
+		"_id": "10.9999/maxiv_pub1",
 		"creator": [
 			"Rajmund Mokso",
 			"al."
@@ -150,7 +150,7 @@
 		}
 	},
 	{
-		"_id": "DOI.SAMPLE.PREFIX/maxiv_pub2",
+		"_id": "10.9999/maxiv_pub2",
 		"creator": [
 			"Maik Kahnt",
 			"al."
@@ -187,7 +187,7 @@
 		}
 	},
 	{
-		"_id": "DOI.SAMPLE.PREFIX/psi_pub1",
+		"_id": "10.9999/psi_pub1",
 		"creator": [
 			"Elena Borisova",
 			"Goran Lovric",
@@ -233,7 +233,7 @@
 		}
 	},
 	{
-		"_id": "DOI.SAMPLE.PREFIX/soleil_pub1",
+		"_id": "10.9999/soleil_pub1",
 		"creator": [
 			"Doru Constantin",
 			"al."
@@ -268,7 +268,7 @@
 		}
 	},
 	{
-		"_id": "DOI.SAMPLE.PREFIX/ukri_pub1",
+		"_id": "10.9999/ukri_pub1",
 		"creator": [
 			"Franz Lang"
 		],
@@ -305,7 +305,7 @@
 		}
 	},
 	{
-		"_id": "DOI.SAMPLE.PREFIX/ukri_pub3",
+		"_id": "10.9999/ukri_pub3",
 		"creator": [
 			"Chiara Triestino"
 		],
@@ -341,7 +341,7 @@
 		}
 	},
 	{
-		"_id": "DOI.SAMPLE.PREFIX/ukri_pub4",
+		"_id": "10.9999/ukri_pub4",
 		"creator": [
 			"Gabriel Bernardo"
 		],
@@ -378,7 +378,7 @@
 		}
 	},
 	{
-		"_id": "DOI.SAMPLE.PREFIX/dls_pub2",
+		"_id": "10.9999/dls_pub2",
 		"creator": [
 			"Duncan N. Johnstone",
 			"al."


### PR DESCRIPTION
The current example prefix is not valid.

> A DOI prefix always starts with '10.' and continues with a number (e.g. '10.1234' or '10.20865').

The `10.9999` prefix doesn't seem to be assigned so I think it is safe to use it as an example.
See: https://commons.datacite.org/?query=10.9999