### PR TITLE
fix: remove cache from release

### DIFF
--- a/.github/workflows/semantic_release.yaml
+++ b/.github/workflows/semantic_release.yaml
@@ -24,7 +24,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
       - name: Install dependencies
         run: npm install --no-package-lock
       - name: Release


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Cache in workflow without package-lock.json make the CI fail

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* npm cache option removed
