### PR TITLE
fix: clean untracked files

### DIFF
--- a/entrypoints/setup_git.sh
+++ b/entrypoints/setup_git.sh
@@ -14,5 +14,6 @@ git remote add origin "${REPO}"
 git fetch
 DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
 git reset --hard origin/"${TAG:-$DEFAULT_BRANCH}"
+git clean -fd
 
 echo ".finished" >> .git/info/exclude


### PR DESCRIPTION
this can happen as the cached docker image "latest" does not coincide with the latest master. The reset will move head to origin/master but will not remove files that went untracked. This does it

<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
the cached docker image "latest" does not coincide with the latest master. The reset will move head to origin/master but will not remove files that went untracked. This does it

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* git clean -fd removes untracked
