### PR TITLE
fix: reverting frontend port to 80

### DIFF
--- a/services/frontend/compose.base.yaml
+++ b/services/frontend/compose.base.yaml
@@ -15,7 +15,7 @@ services:
     labels:
       - traefik.http.routers.frontend.rule=Host(`localhost`)
       # Adding a label for traefik to learn which port to look for a service on
-      - traefik.http.services.frontend.loadbalancer.server.port=8080
+      - traefik.http.services.frontend.loadbalancer.server.port=80
     restart: on-failure
     environment:
       BACKEND_URL: ${BACKEND_HTTPS_URL:-http://backend.localhost}


### PR DESCRIPTION
Revert this once a frontend image with `nginx-unprivileged` is released
