### PR TITLE
docs: standardize structure of READMEs sections

### DIFF
--- a/.github/changed_files.yaml
+++ b/.github/changed_files.yaml
@@ -56,6 +56,8 @@ docs:
   - '**/README.md'
   - '**/*mkdocs*/**'
   - '**/*mkdocs*'
+mds:
+  - '**/*.md'
   - '**/*markdownlint*'
   - '**/*markdownlint*/**'
 dev:

--- a/.github/markdownlint/.markdownlint-cli2.yaml
+++ b/.github/markdownlint/.markdownlint-cli2.yaml
@@ -1,0 +1,2 @@
+customRules:
+  - .markdownlint-rule-structure.js

--- a/.github/markdownlint/.markdownlint-rule-structure.js
+++ b/.github/markdownlint/.markdownlint-rule-structure.js
@@ -1,0 +1,81 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const getFileParts = (filePath) => {
+  const relativePath = path.relative(`${process.cwd()}`, filePath);
+  return relativePath.split(path.sep).filter(part => part !== "..");
+}
+
+const getRequiredSections = (params, parts) => {
+  const fileName = parts[parts.length - 2];
+  const hasDependencies = fs.existsSync(`${path.dirname(params.name)}/services`);
+
+  const requiredSections = [
+    new RegExp(`^# \\[?${fileName[0].toUpperCase()}${fileName.slice(1)}\\]?`, "m"),
+    /^## Configuration options$/m,
+    /^## Default configuration$/m,
+    /^## Enable additional features$/m,
+    ...(hasDependencies && [/^## Dependencies$/m] || []),
+  ];
+  return requiredSections;
+}
+
+const checkRequiredSections = (params, onError) => {
+    const parts = getFileParts(params.name);
+    if (parts[0] !== "services") return;
+    const requiredSections = getRequiredSections(params, parts);
+    const content = params.lines.join("\n");
+
+    requiredSections.forEach((regex) => {
+      const match = content.match(regex);
+      if (!match)
+        onError({
+          lineNumber: 1,
+          detail: `Context: ${regex.source}`,
+        });
+    });
+}
+
+const checkSectionsOrder = (params, onError) => {
+    const parts = getFileParts(params.name);
+    if (parts[0] !== "services") return;
+    const requiredSections = getRequiredSections(params, parts);
+    const content = params.lines.join("\n");
+
+    const matches = [];
+    let expectedOrder = "";
+    let wrongOrder = false;
+    let lastIndex = -1;
+    for (const regex of requiredSections) {
+      const match = content.match(regex);
+      if (!match) continue;
+      if (match.index < lastIndex) wrongOrder = true;
+      expectedOrder += regex.source + ", ";
+      matches.push([regex.source, match.index]);
+      lastIndex = match.index;
+    }
+
+    if (!wrongOrder) return;
+    const foundOrder = [...matches].sort((a, b) => a[1] - b[1]).map(m => m[0]);
+    onError({
+      lineNumber: 1,
+      detail: `Context: found order: ${foundOrder.join(", "
+      )}, expected order: ${expectedOrder.slice(0, -2)}`,
+    });
+  }
+
+module.exports = [
+  {
+    names: ["required-sections"],
+    description: "Missing required section",
+    tags: ["structure", "headings"],
+    function: checkRequiredSections,
+  },
+  {
+    names: ["misordered-sections"],
+    description: "Wrong sections order",
+    tags: ["structure", "headings"],
+    function: checkSectionsOrder,
+  }]

--- a/.github/markdownlint/.markdownlint.yaml
+++ b/.github/markdownlint/.markdownlint.yaml
@@ -1,3 +1,5 @@
+extends: .markdownlint-cli2.yaml
+
 MD013:
   line_length: 120
   tables: false

--- a/.github/workflows/compose_test.yaml
+++ b/.github/workflows/compose_test.yaml
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - changes
-    if: fromJson(needs.changes.outputs.all).docs_all_modified_files
+    if: fromJson(needs.changes.outputs.all).mds_all_modified_files
     steps:
       - uses: actions/checkout@v5
       - run: cp -r .github/markdownlint/. .
@@ -99,6 +99,7 @@ jobs:
       - yaml-lint
       - python-lint
       - javascript-lint
+      - markdown-lint
     if: >
       !failure()
       && !cancelled()

--- a/services/backend/README.md
+++ b/services/backend/README.md
@@ -1,6 +1,15 @@
-# Backend service
+# Backend
 
 The SciCat backend HTTP service.
+
+## Configuration options
+
+For a list of configuration options, please look at [v3](./services/v3/README.md#configuration-options)
+or [v4](./services/v3/README.md#configuration-options) options.
+
+## Default configuration
+
+By default [v4](./services/v4/README.md) is used.
 
 ## Enable additional features
 
@@ -14,7 +23,7 @@ either in the v3 [compose.oidc.yaml](./services/v3/compose.oidc.yaml) and
 Additionally, by setting the env variable `JOBS_ENABLED`, the [rabbitmq](./services/rabbitmq/) service is started and
 the backend configured to connect to it.
 
-##  Dependencies
+## Dependencies
 
 Here below we show the internal dependencies of the service, which are not already covered in
 [the root docs](../../README.md) (if `B` depends on `A`, then we visualize it as `A --> B`). The same subdomain to

--- a/services/backend/services/keycloak/README.md
+++ b/services/backend/services/keycloak/README.md
@@ -26,3 +26,7 @@ Also a realm called `facility` is created with the following user and group:
 The users' groups are passed to SciCat backend via the OIDC ID Token, in the claim named `accessGroups` (an array of
 strings). The name of the claim can be configured either in [login-callbacks.js](../v3/config/login-callbacks.js) for v3
 or with [environment variables](../v4/config/.oidc.env) for v4.
+
+## Enable additional features
+
+Setting the [KEYCLOAK_HTTPS_URL env variable](../../../../.env) enables changing the keycloak URL and adds to it TLS termination.

--- a/services/backend/services/ldap/README.md
+++ b/services/backend/services/ldap/README.md
@@ -1,4 +1,4 @@
-# LDAP (OpenLDAP)
+# Ldap (OpenLDAP)
 
 LDAP (Lightweight Directory Access Protocol) is a protocol used to access and manage directory information such as user
 credentials. SciCat can use LDAP as third-party authentication provider.
@@ -19,3 +19,7 @@ The default configuration [.env file](./config/.env) creates the `dc=facility` d
 | Username  | Password |
 | --------- | -------- |
 | ldap-user | password |
+
+## Enable additional features
+
+No additional features.

--- a/services/backend/services/mongodb/README.md
+++ b/services/backend/services/mongodb/README.md
@@ -26,6 +26,10 @@ When `DEV=true` and `BE_VERSION=v4` the seeding writes to `dev-dacat-next`.
 For an explanation of how setting `BE_VERSION` changes the environment creation see the
 [configuration options in the root docs](../../../../README.md#docker-compose-profiles-and-env-variables-configuration-options).
 
+## Enable additional features
+
+No additional features.
+
 ## Dependency on `BE_VERSION`
 
 Since [v3](../v3/) and [v4](../v4/) connect to two different DBs, the [BE_VERSION](./compose.yaml#L9) environment

--- a/services/backend/services/v3/README.md
+++ b/services/backend/services/v3/README.md
@@ -1,4 +1,4 @@
-# [Backend v3](https://github.com/SciCatProject/backend)
+# [V3](https://github.com/SciCatProject/backend)
 
 The SciCat backend v3 is the SciCat metadata catalogue RESTful API layer, built on top of the Loopback framework.
 
@@ -84,7 +84,7 @@ With `DEV=true`, since the v3 tests are supposed to run with an empty DB, the se
 [dacat_test](./config/datasources.dev.json) which is empty. If willing to use the seeded one later during development,
 just set `dacat` as database values in the file `/home/node/app/server/datasources.json` on the container.
 
-##  Dependencies
+## Dependencies
 
 Here below we show the internal dependencies of the service, which are not already covered in
 [the root docs](../../README.md) and in the [common backend docs](../../README.md) (if `B` depends on `A`, then we

--- a/services/backend/services/v3/services/archivemock/README.md
+++ b/services/backend/services/v3/services/archivemock/README.md
@@ -1,4 +1,4 @@
-# [Archive Mock](https://github.com/SwissOpenEM/ScicatArchiveMock)
+# [Archivemock](https://github.com/SwissOpenEM/ScicatArchiveMock)
 
 The Archive Mock simulates the interactions of an archival mock with SciCat.
 
@@ -7,14 +7,20 @@ The Archive Mock simulates the interactions of an archival mock with SciCat.
 - [RabbitMQ](../../../rabbitmq/)
 - [backend v3](../../) (configured to use the RabbitMQ instance above for jobs)
 
-## [Config](./config/.env) - Environment Variables
+## Configuration options
 
 The container uses
 [environment variables](https://github.com/SwissOpenEM/ScicatArchiveMock?tab=readme-ov-file#utility-scripts) for
-configuration.
+configuration. These are set in [./config/.env](./config/.env)
 
-## Default configuraiton
+## Default configuration
 
 By default, it is configured to connect to the [backend v3](../../) container with the `admin` account, and to the
 [RabbitMQ](../../../rabbitmq/) container with the `guest` account. It will then handle all archival and retrieval jobs
 posted to RabbitMQ, and update the corresponding Datasets accordingly in Scicat.
+
+## Enable additional features
+
+`DEV=true` enables running the archivemock in DEV mode.
+
+`JOBS_ENABLED` and `BE_VERSION=v3` creates the archivemock service which listens to messages submitted to [rabbitmq](../../../rabbitmq/).

--- a/services/backend/services/v4/README.md
+++ b/services/backend/services/v4/README.md
@@ -1,4 +1,4 @@
-# [Backend v4](https://github.com/SciCatProject/scicat-backend-next)
+# [V4](https://github.com/SciCatProject/scicat-backend-next)
 
 The SciCat backend v4 is a rewrite of the original backend, built on top of the NestJS framework.
 
@@ -36,7 +36,7 @@ With `DEV=true`, since the container might have limited memory, it is recommende
 `--runInBand`, as [./entrypoints/tests.sh](./entrypoints/tests.sh), which makes the tests run sequentially, avoiding to
 fill the RAM which makes them freeze.
 
-##  Dependencies
+## Dependencies
 
 Here below we show the internal dependencies of the service, which are not already covered in
 [the root docs](../../README.md) and in the [common backend docs](../../README.md) (if `B` depends on `A`, then we

--- a/services/jupyter/README.md
+++ b/services/jupyter/README.md
@@ -1,9 +1,14 @@
-# Jupyter Notebook
+# Jupyter
 
 This Jupyter Notebook instance is preconfigured with an example notebook that shows the usage of
 [Pyscicat](https://github.com/scicatproject/pyscicat).
 
-## [Pyscicat Notebook](./config/notebooks/pyscicat.ipynb)
+## Configuration options
+
+The [.env file](./config/.env) contains the environment variables for connecting to the backend service deployed by
+this project.
+
+### [Pyscicat Notebook](./config/notebooks/pyscicat.ipynb)
 
 This notebook demonstrates all the major actions Pyscicat is capable of:
 
@@ -12,11 +17,7 @@ This notebook demonstrates all the major actions Pyscicat is capable of:
 - datablock creation
 - attachment upload
 
-## [.env file](./config/.env)
-
-It contains the environment variables for connecting to the backend service deployed by this project
-
-## [Thumbnail image](./config/notebooks/example_files/thumbnail.png)
+### [Thumbnail image](./config/notebooks/example_files/thumbnail.png)
 
 An example image that is used for the attachment upload demonstration
 
@@ -30,3 +31,7 @@ these notebooks should _not_ be contributed back to this repository, unless this
 upstream changes to these notebooks, be sure to clear all the results from them.
 
 The [main readme](../../README.md) covers all dependencies of this package.
+
+## Enable additional features
+
+`--profile 'analysis'` instructs docker compose to create this additional service.

--- a/services/landingpage/README.md
+++ b/services/landingpage/README.md
@@ -31,3 +31,5 @@ Setting the [BACKEND_HTTPS_URL and FRONTEND_HTTPS_URL env variables](../../.env)
 
 With `DEV=true`, please use `npm start -- --host 0.0.0.0`. This is to allow traffic from any IP to the `landingpage`
 component and it is necessary since the component runs in the docker network.
+
+`--profile 'search'` instructs docker compose to create this additional service.

--- a/services/oaipmh/README.md
+++ b/services/oaipmh/README.md
@@ -1,4 +1,4 @@
-# [OAIPMH](https://github.com/SciCatProject/oai-provider-service)
+# [Oaipmh](https://github.com/SciCatProject/oai-provider-service)
 
 SciCat supports querying published metadata via the [OAI-PMH protocol](https://www.openarchives.org/pmh/)
 
@@ -22,6 +22,8 @@ This is managed in the env file [./config/.env](./config/.env).
 
 :warning: When setting `OAIPMH_HTTPS_URL` it is likely you also want to set the `BACKEND_HTTPS_URL`, to allow the
 communication between the two wherever the browser is accessed.
+
+`--profile 'search'` instructs docker compose to create this additional service.
 
 ## DEV configuration
 

--- a/services/proxy/README.md
+++ b/services/proxy/README.md
@@ -2,7 +2,7 @@
 
 The proxy acts as a reverse proxy to the SciCat Live containers.
 
-## Configuration
+## Configuration options
 
 ### [.env file](./config/.env)
 
@@ -15,7 +15,14 @@ reachable from the public web.
 
 You need to set the letsencrypt options in the [./config/.tls.env](./config/.tls.env) file.
 
-## Enable TLS
+## Default configuration
+
+By default, all services are exposed on localhost with no TLS termination, and following the convention:
+
+- frontend: `http://localhost`
+- other services: `http://{service}.localhost`
+
+## Enable additional features
 
 To enable TLS on specific services, you can set the `<SERVICE>_HTTPS_URL` env var to the desired URL, including the
 `https://` prefix, making sure that the URLs are reachable by `letsencrypt`. See the root .env [../../.env](../../.env)

--- a/services/searchapi/README.md
+++ b/services/searchapi/README.md
@@ -3,12 +3,8 @@
 The SciCat seachAPI is the SciCat metadata catalogue standardised API for communication between SciCat and the PaN
 portal, built on top of the Loobpack framework.
 
-## Configuration options
-
 The searchapi configuration is set by the [.env file](./config/.env). For an extensive list of available options see the
 [upstream documentation](https://github.com/SciCatProject/panosc-search-api).
-
-## Default configuration
 
 In the default configuration [.env file](./config/.env), the searchapi is set to call the `backend service` available at
 `backend.localhost` (either [v4](../backend/services/v4/), by default, or [v3](../backend/services/v3/) if specified
@@ -19,6 +15,10 @@ For an explanation of how setting `BE_VERSION` changes the environment creation 
 
 ## Enable additional features
 
+## Enable additional features
+
 `DEV=true` enables running the archivemock in DEV mode.
 
 `--profile 'search'` instructs docker compose to create this additional service.
+
+## Default configuration

--- a/services/searchapi/README.md
+++ b/services/searchapi/README.md
@@ -3,8 +3,12 @@
 The SciCat seachAPI is the SciCat metadata catalogue standardised API for communication between SciCat and the PaN
 portal, built on top of the Loobpack framework.
 
+## Configuration options
+
 The searchapi configuration is set by the [.env file](./config/.env). For an extensive list of available options see the
 [upstream documentation](https://github.com/SciCatProject/panosc-search-api).
+
+## Default configuration
 
 In the default configuration [.env file](./config/.env), the searchapi is set to call the `backend service` available at
 `backend.localhost` (either [v4](../backend/services/v4/), by default, or [v3](../backend/services/v3/) if specified
@@ -15,10 +19,6 @@ For an explanation of how setting `BE_VERSION` changes the environment creation 
 
 ## Enable additional features
 
-## Enable additional features
-
 `DEV=true` enables running the archivemock in DEV mode.
 
 `--profile 'search'` instructs docker compose to create this additional service.
-
-## Default configuration

--- a/services/searchapi/README.md
+++ b/services/searchapi/README.md
@@ -16,3 +16,9 @@ otherwise by setting `BE_VERSION`).
 
 For an explanation of how setting `BE_VERSION` changes the environment creation see the
 [configuration options in the root docs](../../README.md#docker-compose-profiles-and-env-variables-configuration-options).
+
+## Enable additional features
+
+`DEV=true` enables running the archivemock in DEV mode.
+
+`--profile 'search'` instructs docker compose to create this additional service.


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

<!-- markdownlint-disable-next-line first-line-h1 -->
## Description
Sets custom markdownlint rules to enforce a standard structure to READMEs under the `service/` folder.

## Motivation

To have a consistent structure of services READMEs

## Changes

<!-- Please provide a list of the changes implemented by this PR -->

- all READMEs now follow predefined structure
- script to check mandatory sections and order added
- changed files split into mds and docs (one for markdownlint and one for mkdocs)
