### PR TITLE
docs: enforce 1st headings to link https docs

### DIFF
--- a/.github/markdownlint/.markdownlint-rule-structure.js
+++ b/.github/markdownlint/.markdownlint-rule-structure.js
@@ -13,7 +13,7 @@ const getRequiredSections = (params, parts) => {
   const hasDependencies = fs.existsSync(`${path.dirname(params.name)}/services`);
 
   const requiredSections = [
-    new RegExp(`^# \\[?${fileName[0].toUpperCase()}${fileName.slice(1)}\\]?`, "m"),
+    new RegExp(`^# \\[${fileName[0].toUpperCase()}${fileName.slice(1)}\\]\\(https?://[^)]+\\)`, "m"),
     /^## Configuration options$/m,
     /^## Default configuration$/m,
     /^## Enable additional features$/m,

--- a/services/backend/README.md
+++ b/services/backend/README.md
@@ -1,4 +1,4 @@
-# Backend
+# [Backend](https://www.scicatproject.org/documentation/Development/)
 
 The SciCat backend HTTP service.
 

--- a/services/backend/services/keycloak/README.md
+++ b/services/backend/services/keycloak/README.md
@@ -1,4 +1,4 @@
-# Keycloak (OIDC Identity provider)
+# [Keycloak](https://www.keycloak.org/)
 
 OIDC is an authentication protocol that verifies user identities when they sign in to access digital resources. SciCat
 can use an OIDC service as third-party authentication provider.

--- a/services/backend/services/ldap/README.md
+++ b/services/backend/services/ldap/README.md
@@ -1,4 +1,4 @@
-# Ldap (OpenLDAP)
+# [Ldap](https://www.openldap.org/)
 
 LDAP (Lightweight Directory Access Protocol) is a protocol used to access and manage directory information such as user
 credentials. SciCat can use LDAP as third-party authentication provider.

--- a/services/backend/services/mongodb/README.md
+++ b/services/backend/services/mongodb/README.md
@@ -1,4 +1,4 @@
-# Mongodb
+# [Mongodb](https://www.mongodb.com/)
 
 The `mongodb` container is responsible of creating a mongodb container with initial metadata.
 

--- a/services/jupyter/README.md
+++ b/services/jupyter/README.md
@@ -1,4 +1,4 @@
-# Jupyter
+# [Jupyter](https://jupyter.org/)
 
 This Jupyter Notebook instance is preconfigured with an example notebook that shows the usage of
 [Pyscicat](https://github.com/scicatproject/pyscicat).


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

<!-- markdownlint-disable-next-line first-line-h1 -->
## Description

Enforce 1st headings to link https docs. This is enforced by the customRule regex in markdwonlint

## Changes

<!-- Please provide a list of the changes implemented by this PR -->

- add rule to enforce https link in READMEs title
- add link in READMEs where missing
