### PR TITLE
chore: use default dir rather than copying

### DIFF
--- a/.github/workflows/compose_test.yaml
+++ b/.github/workflows/compose_test.yaml
@@ -87,11 +87,10 @@ jobs:
     if: fromJson(needs.changes.outputs.all).mds_all_modified_files
     steps:
       - uses: actions/checkout@v5
-      - run: cp -r .github/markdownlint/. .
       - uses: DavidAnson/markdownlint-cli2-action@v20
         with:
           globs: '**/*.md'
-          config: .markdownlint.yaml
+          config: .github/markdownlint/.markdownlint.yaml
   check-mkdocs:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

Avoid copying files into root and simply reference config in action.with
