### PR TITLE
fix: fix semantic release syntax

### DIFF
--- a/.github/semantic-release/.releaserc.yaml
+++ b/.github/semantic-release/.releaserc.yaml
@@ -10,4 +10,4 @@ plugins:
   -
     - '@semantic-release/exec'
     - publishCmd: VERSION=${nextRelease.version} node publish-oci.js
-    - successCmd: echo "tag=${nextRelease.gitTag}" >> $GITHUB_OUTPUT
+      successCmd: echo "tag=${nextRelease.gitTag}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

Fix semantic release configuration syntax by removing extra dash

