### PR TITLE
fix: permission errors when using compose w/ podman

### DIFF
--- a/services/proxy/compose.yaml
+++ b/services/proxy/compose.yaml
@@ -7,6 +7,8 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - letsencrypt_proxy_data:/letsencrypt
+    security_opt:
+      - label=disable
     configs:
       - source: proxy_https_services_sh
         target: /https_services.sh

--- a/services/proxy/compose.yaml
+++ b/services/proxy/compose.yaml
@@ -7,6 +7,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - letsencrypt_proxy_data:/letsencrypt
+    # selinux separation cannot be used w/ access to the hosts docker socket
     security_opt:
       - label=disable
     configs:


### PR DESCRIPTION
# Description

Disable SELinux relabling for docker/podman socket to fix permission errors