### PR TITLE
feat(ldap-auth): configure ldap group retrieval and ldap username attribute

### DIFF
--- a/services/backend/services/v4/config/.ldap.env
+++ b/services/backend/services/v4/config/.ldap.env
@@ -3,3 +3,8 @@ LDAP_SEARCH_BASE=ou=users,dc=facility
 LDAP_SEARCH_FILTER=(uid={{username}})
 LDAP_BIND_DN=cn=scicatlive-svc,ou=svc-acc,dc=facility
 LDAP_BIND_CREDENTIALS=mysecret
+ACCESS_GROUPS_LDAPPAYLOAD_ENABLED=true
+LDAP_ACCESS_GROUPS_PROPERTY=cn
+LDAP_USERNAME_ATTR=uid
+LDAP_GROUP_SEARCH_BASE=ou=groups,dc=facility
+LDAP_GROUP_SEARCH_FILTER="(uniqueMember=cn={{username}},*ou=users,dc=facility)"


### PR DESCRIPTION
# Description

Creates a default configuration for access group(s) retrieval and resolving the username by ldap attributes in the corresponding ldap environment file. However, the configuration is not enabled by default.

Please take into account that this PR needs an updated backend with the patch referenced in the corresponding commit.
