### PR TITLE
feat: support volume mounts with ocis for mods

### DIFF
--- a/.github/semantic-release/publish-oci.js
+++ b/.github/semantic-release/publish-oci.js
@@ -13,6 +13,166 @@ const imagePath = `ghcr.io/${repo}`;
 
 const ociTypes = ["", "-full", "-v3", "-v3-full"];
 
+// ---------------------------------------------------------------------------
+// Reverse conversion: bind-mount volumes (single files) -> inline configs.
+//
+// Rationale: `docker compose publish` needs a fully self-contained artifact.
+// A `configs:` entry with `file:` can be inlined (see step 2 below), but a
+// `volumes:` bind mount referencing a host file has no equivalent in the
+// published artifact at all - it just silently won't exist for whoever
+// pulls the OCI package. Anything a dev workflow deliberately mounted as a
+// writable volume (see prior discussion) needs to be converted back to a
+// read-only config for publishing, since that's the only mechanism Compose
+// supports for embedding file content in an OCI artifact.
+//
+// This only touches bind mounts that point at a single existing file.
+// Named volumes (declared under the top-level `volumes:` key, e.g. DB data
+// directories) and directory bind mounts are left untouched - configs can't
+// represent either of those, so if you need one of those to also ship in
+// the OCI artifact, that's a different problem (named volume seeding, or
+// baking a directory into the image itself).
+// ---------------------------------------------------------------------------
+// Host resources that must never be embedded in the published artifact,
+// even though they may resolve to a "file" on whatever machine runs this
+// script. The Docker socket is the main case: it's a bind mount the proxy
+// needs at runtime on the *host* it's deployed to, not build-time content
+// to bake into a config.
+const NON_CONVERTIBLE_SOURCES = new Set(["/var/run/docker.sock"]);
+
+function namedVolumeNames(doc) {
+  const topVolumes = doc.get("volumes", true);
+  if (!topVolumes || !topVolumes.items) return new Set();
+  return new Set(topVolumes.items.map((pair) => pair.key.value));
+}
+
+function parseVolumeEntry(item) {
+  // Short syntax: "source:target" or "source:target:mode"
+  if (item instanceof yaml.Scalar || typeof item.value === "string") {
+    const parts = item.value.split(":");
+    if (parts.length < 2) return null;
+    return { source: parts[0], target: parts[1] };
+  }
+  // Long syntax: {type, source, target, ...}
+  if (item.get) {
+    const type = item.get("type");
+    const source = item.get("source");
+    const target = item.get("target");
+    if (type && type !== "bind") return null; // skip named volume/tmpfs/npipe types
+    if (!source || !target) return null;
+    return { source, target };
+  }
+  return null;
+}
+
+function sanitizeConfigName(serviceName, targetPath) {
+  const stripped = targetPath.replace(/^\/+/, "");
+  return `${serviceName}_${stripped}`.replace(/[^a-zA-Z0-9_.-]+/g, "_");
+}
+
+function inlineFileContent(absPath) {
+  const buffer = fs.readFileSync(absPath);
+  // Check for null byte (0) to identify binary data
+  return buffer.includes(0)
+    ? buffer.toString("base64")
+    : buffer.toString("utf8").replace(/\$/g, "$$$$");
+}
+
+function ensureTopConfigs(doc) {
+  let topConfigs = doc.get("configs", true);
+  if (!topConfigs) {
+    doc.set("configs", doc.createNode({}));
+    topConfigs = doc.get("configs", true);
+  }
+  return topConfigs;
+}
+
+function addServiceConfigRefs(doc, service, newConfigRefs) {
+  if (!newConfigRefs.length) return;
+
+  let serviceConfigs = service.get("configs", true);
+  if (!serviceConfigs) {
+    service.set("configs", doc.createNode([]));
+    serviceConfigs = service.get("configs", true);
+  }
+  newConfigRefs.forEach((ref) => serviceConfigs.add(doc.createNode(ref)));
+}
+
+function convertVolumeItem(doc, baseDir, named, topConfigs, serviceName, item) {
+  const parsed = parseVolumeEntry(item);
+
+  if (
+    !parsed ||
+    named.has(parsed.source) ||
+    NON_CONVERTIBLE_SOURCES.has(parsed.source)
+  ) {
+    return null; // named volume, unparseable, or non-convertible host resource - leave as-is
+  }
+
+  const absSourcePath = path.resolve(baseDir, parsed.source);
+  let isFile;
+  try {
+    isFile = fs.statSync(absSourcePath).isFile();
+  } catch {
+    return null; // source doesn't exist on disk - leave as-is
+  }
+  if (!isFile) {
+    return null; // directory bind mount - configs can't represent this
+  }
+
+  const configName = sanitizeConfigName(serviceName, parsed.target);
+  topConfigs.set(
+    configName,
+    doc.createNode({ content: inlineFileContent(absSourcePath) }),
+  );
+  return { source: configName, target: parsed.target };
+}
+
+function convertServiceVolumes(doc, baseDir, named, topConfigs, servicePair) {
+  const serviceName = servicePair.key.value;
+  const service = servicePair.value;
+  const volumes = service.get("volumes", true);
+  if (!volumes || !volumes.items) return;
+
+  const keepVolumes = [];
+  const newConfigRefs = [];
+
+  for (const item of volumes.items) {
+    const configRef = convertVolumeItem(
+      doc,
+      baseDir,
+      named,
+      topConfigs,
+      serviceName,
+      item,
+    );
+    if (configRef) {
+      newConfigRefs.push(configRef);
+    } else {
+      keepVolumes.push(item);
+    }
+  }
+
+  volumes.items = keepVolumes;
+
+  addServiceConfigRefs(doc, service, newConfigRefs);
+
+  if (volumes.items.length === 0) {
+    service.delete("volumes");
+  }
+}
+
+function convertVolumesToConfigs(doc, baseDir) {
+  const services = doc.get("services", true);
+  if (!services) return;
+
+  const named = namedVolumeNames(doc);
+  const topConfigs = ensureTopConfigs(doc);
+
+  for (const servicePair of services.items) {
+    convertServiceVolumes(doc, baseDir, named, topConfigs, servicePair);
+  }
+}
+
 ociTypes.forEach((ociType) => {
   const dockerEnv = {
     ...process.env,
@@ -31,30 +191,28 @@ ociTypes.forEach((ociType) => {
       { env: dockerEnv, cwd: COMPOSE_BASE_DIR },
     );
 
-    // 2. Inline file contents
     const doc = yaml.parseDocument(
       fs.readFileSync(COMPOSE_RESOLVED_FILE, "utf8"),
     );
-    const configs = doc.get("configs");
 
+    // 2. Convert any bind-mount volumes (single files) into configs
+    convertVolumesToConfigs(doc, COMPOSE_BASE_DIR);
+
+    // 3. Inline remaining file-based config content
+    const configs = doc.get("configs");
     if (configs) {
       configs.items.forEach((item) => {
         const node = item.value || item;
         const fileNode = node.get("file", true);
         if (!fileNode) return;
         const filePath = path.join(COMPOSE_BASE_DIR, fileNode.value);
-        const buffer = fs.readFileSync(filePath);
-        // Check for null byte (0) to identify binary data
-        const content = buffer.includes(0)
-          ? buffer.toString("base64")
-          : buffer.toString("utf8").replace(/\$/g, "$$$$");
-        node.set("content", content);
+        node.set("content", inlineFileContent(filePath));
         node.delete("file");
       });
     }
     fs.writeFileSync(COMPOSE_RESOLVED_FILE, doc.toString());
 
-    // 3. Publish
+    // 4. Publish
     const ociTags = [
       `${imagePath}:${version}${ociType}`,
       `${imagePath}:latest${ociType}`,

--- a/README.md
+++ b/README.md
@@ -380,8 +380,9 @@ To ease the iterative execution of multiple init scripts, one can leverage the
 [loop_entrypoints](./entrypoints/loop_entrypoints.sh) utility, which loops alphabetically over
 `/docker-entrypoinst/*.sh` and executes each. This is in use in some services (e.g. in the
 [frontend](./services/frontend/compose.yaml)), so one can add additional init steps by mounting them, one by one, as
-bind mounts inside the container in the `/docker-entrypoints` folder and naming them depending on the desired order
-(eventually rename the existing ones as well).
+[docker compose configs](https://docs.docker.com/reference/compose-file/services/#configs) inside the container in
+the `/docker-entrypoints` folder and naming them depending on the desired order (eventually rename the existing ones
+as well).
 
 #### If the service does not support entrypoints yet, one needs to
 
@@ -406,10 +407,15 @@ Please note that services should, in general, be defined by their responsibility
 technology, and should be named so.
 
 :warning: When adding a new service, please use [docker compose configs](https://docs.docker.com/reference/compose-file/services/#configs)
-for mounting files inside the container, rather than bind mounts, as they are more robust and easier to maintain.
-This is mostly relevant for the published OCI packages, as bind mounts require the user to have specific files in
-their local environment, which might not be the case, while configs are included in the package itself as part
-of the [release workflow](./.github/semantic-release/publish-oci.js).
+for mounting files inside the container, unless the mounted file needs to be modified from within the container, in
+which case use a bind-mount volume instead, since configs are always mounted read-only. This distinction is mostly
+relevant for the published OCI packages: bind mounts pointing at directories, or at files that no longer exist on
+disk, require the user to have those in their local environment, which might not be the case, so they are left
+untouched by the [release workflow](./.github/semantic-release/publish-oci.js); single-file bind mounts, however, are
+converted to configs by that same workflow, so they work in the published package too. The generated config is named
+`<service>_<target-path>`, with the mount's target path stripped of its leading slash and any remaining non-alphanumeric
+character replaced by `_` (e.g. a `proxy` service mount targeting `/config/traefik.yaml` becomes a config named
+`proxy_config_traefik.yaml`).
 
 ### Basic
 

--- a/services/backend/services/v4/compose.jobs.yaml
+++ b/services/backend/services/v4/compose.jobs.yaml
@@ -6,12 +6,7 @@ services:
     depends_on:
       rabbitmq:
         condition: service_healthy
-    configs:
-      - source: backend_v4_job_config_yaml
-        target: /home/node/app/jobConfig.yaml
+    volumes:
+      - ./config/jobConfig.yaml:/home/node/app/jobConfig.yaml
     env_file:
       - ./config/.jobs.env
-
-configs:
-  backend_v4_job_config_yaml:
-    file: ./config/jobConfig.yaml


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

As configs are mounted inside the container read-only, using them in all cases in place of volume mounts prevents editing inside the container when in DEV mode. This PR introduces bind volumes to config conversion when publishing OCIs. This allows to use volumes for files that provide configs but should be editable from within the container, without breaking the oci packaging.

The generated config is named `<service>_<target-path>`, with the mount's target path stripped of its leading slash and any remaining non-alphanumeric character replaced by `_` (e.g. a `proxy` service mount targeting `/config/traefik.yaml` becomes a config named `proxy_config_traefik.yaml`).

## Changes

<!-- Please provide a list of the changes implemented by this PR -->

- support volumes to config conversion in oci packaging

### Changes checklist

#### Modified Service?

- [ ] Steps from [features](/README.md#features) in README checked

#### New Service?

- [ ] Steps from [new service (advanced)](/README.md#advanced) in README checked
