### PR TITLE
fix: accept 403 when using lychees

### DIFF
--- a/.github/workflows/compose_test.yaml
+++ b/.github/workflows/compose_test.yaml
@@ -91,7 +91,9 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: >-
-            --no-progress --root-dir . '**/*.md'
+            --no-progress --root-dir .
+            --accept '100..=103,200..=299,403,429'
+            '**/*.md'
           fail: true
       - uses: DavidAnson/markdownlint-cli2-action@v24
         with:


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

Accept 403s as valid return codes to prevent targets blocking runners to stop the workflow with error

## Fixes

- Accept 403s as valid return codes
