### PR TITLE
feat: add mkdocs container and mount docs folders

### DIFF
--- a/.github/changed_files.yaml
+++ b/.github/changed_files.yaml
@@ -56,6 +56,9 @@ docs:
   - '**/README.md'
   - '**/*mkdocs*/**'
   - '**/*mkdocs*'
+docs_service: &docs_service
+  - services/docs/**
+  - '!services/docs/**/README.md'
 mds:
   - '**/*.md'
   - '**/*markdownlint*'
@@ -67,3 +70,4 @@ dev:
   - *opensearch
   - *jobs
   - *other_scicat
+  - *docs_service

--- a/.github/markdownlint/.markdownlint-rule-structure.js
+++ b/.github/markdownlint/.markdownlint-rule-structure.js
@@ -24,7 +24,7 @@ const getRequiredSections = (params, parts) => {
 
 const checkRequiredSections = (params, onError) => {
   const parts = getFileParts(params.name);
-  if (parts[0] !== "services") return;
+  if (parts[0] !== "services" || parts[parts.length - 1] !== "README.md") return;
   const requiredSections = getRequiredSections(params, parts);
   const content = params.lines.join("\n");
 
@@ -40,7 +40,7 @@ const checkRequiredSections = (params, onError) => {
 
 const checkSectionsOrder = (params, onError) => {
   const parts = getFileParts(params.name);
-  if (parts[0] !== "services") return;
+  if (parts[0] !== "services" || parts[parts.length - 1] !== "README.md") return;
   const requiredSections = getRequiredSections(params, parts);
   const content = params.lines.join("\n");
 

--- a/README.md
+++ b/README.md
@@ -297,6 +297,10 @@ to easily install it in the DEV environment. For more details see the
 [openapigenerator README](./services/backend/services/v4/services/openapigenerator/README.md), and for an example of how
 to use it, see the [frontend README](./services/frontend/README.md#dev-configuration).
 
+When `DEV=true`, a [docs](./services/docs/) service also becomes available, rendering a live, combined view of every
+DEV-mode service's own upstream documentation (its `docs/` folder) using MkDocs. See the
+[docs README](./services/docs/README.md) for details, including how to add another service to it.
+
 Please note that [entrypoints](#entrypoints) when `DEV=true` are only run when the component's container is created for
 the first time. This is done to avoid clashes with local changes.
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,6 +6,7 @@ include:
   - services/jupyter/compose.yaml
   - services/landingpage/compose.yaml
   - services/oaipmh/compose.yaml
+  - services/docs/.${DEV:+/}compose.yaml
 
 configs:
   entrypoints_loop_entrypoints_sh:

--- a/services/backend/services/v3/compose.dev.yaml
+++ b/services/backend/services/v3/compose.dev.yaml
@@ -13,6 +13,8 @@ services:
       - source: entrypoints_npm_ci_sh
         target: /docker-entrypoints/20.sh
         mode: 0555
+    volumes:
+      - ./entrypoints/ensure_docs_folder.sh:/docker-entrypoints/03.sh
 
 volumes:
   v3_dev:

--- a/services/backend/services/v3/entrypoints/ensure_docs_folder.sh
+++ b/services/backend/services/v3/entrypoints/ensure_docs_folder.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+## The v3 backend repo has no docs/ folder of its own, but the docs service mounts one from this volume regardless -
+## create it so that mount doesn't fail.
+mkdir -p docs

--- a/services/docs/.compose.yaml
+++ b/services/docs/.compose.yaml
@@ -1,0 +1,1 @@
+../.empty.yaml

--- a/services/docs/README.md
+++ b/services/docs/README.md
@@ -1,0 +1,30 @@
+# [Docs](https://squidfunk.github.io/mkdocs-material/)
+
+Serves a live, combined rendering of every DEV-mode service's own upstream documentation (its `docs/` folder) using
+MkDocs Material.
+
+## Configuration options
+
+### [index.md](./config/index.md)
+
+The landing page served at the site root. Explains what the site is and links to the shared MkDocs configuration.
+
+### [../../.github/mkdocs/](../../.github/mkdocs/)
+
+The shared MkDocs configuration (theme, plugins, [hooks](../../.github/mkdocs/relative_to.py) and
+[requirements](../../.github/mkdocs/requirements.txt)), the same one used to build the official published SciCatLive
+documentation site.
+
+## Default configuration
+
+Only available when running with `DEV=true` (see [DEV configuration](../../README.md#dev-configuration)). Each
+listed service's own `docs/` folder is mounted read-only from its `_dev` volume at `/docs/<service>`, and served
+together at the site root - the git-tracked files themselves are never touched.
+
+By default it serves the `backend` and `frontend` documentation.
+
+## Enable additional features
+
+To render another service's documentation here, add both of the following to [compose.yaml](./compose.yaml):
+
+- a volume mount from that service's own `_dev` volume, using `subpath: docs`, targeting `/docs/<service>`

--- a/services/docs/compose.yaml
+++ b/services/docs/compose.yaml
@@ -1,0 +1,31 @@
+services:
+  docs:
+    image: squidfunk/mkdocs-material:9.7
+    depends_on:
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_healthy
+    volumes:
+      - ${PWD}/.github/mkdocs/:/config/github-mkdocs
+      - ./entrypoints/serve.sh:/usr/local/bin/serve.sh
+      - ./config/index.md:/docs/index.md
+      - type: volume
+        source: ${BE_VERSION:-v4}_dev
+        target: /docs/backend
+        read_only: true
+        volume:
+          subpath: docs
+      - type: volume
+        source: frontend_dev
+        target: /docs/frontend
+        read_only: true
+        volume:
+          subpath: docs
+    restart: on-failure
+    entrypoint: /usr/local/bin/serve.sh
+    environment:
+      GITHUB_SERVER_URL: https://github.com
+      GITHUB_REPOSITORY: SciCatProject/scicatlive
+      CONFIG_DIR: /config/github-mkdocs
+      PYTHONDONTWRITEBYTECODE: 1

--- a/services/docs/config/index.md
+++ b/services/docs/config/index.md
@@ -1,0 +1,34 @@
+# SciCatLive Documentation
+
+This site renders each service's own upstream documentation (its `docs/` folder), live from the checkout running in
+this DEV environment - not a separate, hand-written set of pages.
+
+It's only available when running with `DEV=true`: each service's documentation is only present once that service's
+own container has cloned its repository, so what you see here reflects whatever branch/commit is currently checked
+out in your local dev containers, not necessarily the latest released version.
+
+## Shared styling and configuration
+
+Every service's docs are rendered using the same MkDocs configuration, theme and plugins:
+
+- mkdocs.yaml: `./.github/mkdocs/mkdocs.yaml`
+- theme overrides: `./.github/mkdocs/overrides`
+- relative_to.py hook: `./.github/mkdocs/relative_to.py`
+- requirements.txt: `./.github/mkdocs/requirements.txt`
+
+These are the same files used to build the official published SciCatLive documentation site.
+
+## Adding or changing a service here
+
+Each service listed here is mounted explicitly, not discovered automatically: to add a new service, or change which
+one of an existing service's folders is served, edit the volume mounts in
+`services/docs/compose.yaml`
+adding a `subpath: docs` mount from that service's own `_dev` volume onto `/docs/<service>`.
+
+## Caveats
+
+Because every service is rendered with this shared configuration rather than whatever tooling (if any) it uses
+upstream, the result can differ from how that service renders or publishes its own docs elsewhere - available
+plugins, Markdown extensions and styling all follow this repo's setup, not the upstream project's. Links between two
+services' docs, or to files outside a given service's `docs/` folder, may also not resolve, since each service's
+documentation is normally authored assuming it is the root of its own site.

--- a/services/docs/entrypoints/serve.sh
+++ b/services/docs/entrypoints/serve.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+pip install --no-cache-dir -r "${CONFIG_DIR}/requirements.txt"
+mkdocs serve --config-file "${CONFIG_DIR}/mkdocs.yaml" --dev-addr=0.0.0.0:8000


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

Adds a new service called docs and availalbe at docs.localhost that renders upstream docs when in DEV mode from the services' docs folder. The services to render must be added as volume mounts in the docs container

### Changes checklist

#### Modified Service?

- [ ] Steps from [features](/README.md#features) in README checked

#### New Service?

- [ ] Steps from [new service (advanced)](/README.md#advanced) in README checked
