### PR TITLE
feat: add scicatlive rendered docs when in DEV

### DIFF
--- a/.github/mkdocs/mkdocs.yaml
+++ b/.github/mkdocs/mkdocs.yaml
@@ -1,8 +1,8 @@
 site_name: SciCatLive
 docs_dir: ../../docs
 repo_url: !!python/object/apply:os.path.join [
-  !ENV [GITHUB_SERVER_URL],
-  !ENV [GITHUB_REPOSITORY]
+  !ENV [GITHUB_SERVER_URL, https://github.com],
+  !ENV [GITHUB_REPOSITORY, SciCatProject/scicatlive]
 ]
 theme:
   name: material

--- a/.github/mkdocs/relative_to.py
+++ b/.github/mkdocs/relative_to.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2025, SciCat Project
 # ruff: noqa: INP001,D100
 
 from os import environ
@@ -50,7 +51,13 @@ def on_page_content(html: str, page: Page, config: MkDocsConfig, files: Files) -
             (scheme, netloc, str(resolved_path), query, fragment),
         )
 
-        url = urljoin(repo_url, relative_path)
+        # In the official published site (built in CI) this resolves to the
+        # real file. Locally, docs from multiple repos are aggregated under
+        # one docs_dir, so which upstream repo a link like this really
+        # belongs to can't be reliably determined - point at an explanation
+        # of the rule instead of guessing (possibly wrong) resolved paths.
+        is_ci = "GITHUB_SERVER_URL" in environ
+        url = urljoin(repo_url, relative_path) if is_ci else "/external-links/"
         element["href"] = url
 
     return soup.prettify()

--- a/.github/workflows/compose_test.yaml
+++ b/.github/workflows/compose_test.yaml
@@ -93,6 +93,7 @@ jobs:
           args: >-
             --no-progress --root-dir .
             --accept '100..=103,200..=299,403,429'
+            --exclude-path 'services/docs/config'
             '**/*.md'
           fail: true
       - uses: DavidAnson/markdownlint-cli2-action@v24

--- a/README.md
+++ b/README.md
@@ -298,8 +298,9 @@ to easily install it in the DEV environment. For more details see the
 to use it, see the [frontend README](./services/frontend/README.md#dev-configuration).
 
 When `DEV=true`, a [docs](./services/docs/) service also becomes available, rendering a live, combined view of every
-DEV-mode service's own upstream documentation (its `docs/` folder) using MkDocs. See the
-[docs README](./services/docs/README.md) for details, including how to add another service to it.
+DEV-mode service's own upstream documentation (its `docs/` folder), as well as this repository's own top-level
+documentation, using MkDocs. See the [docs README](./services/docs/README.md) for details, including how to add
+another service to it.
 
 Please note that [entrypoints](#entrypoints) when `DEV=true` are only run when the component's container is created for
 the first time. This is done to avoid clashes with local changes.

--- a/services/docs/README.md
+++ b/services/docs/README.md
@@ -19,9 +19,7 @@ documentation site.
 
 Only available when running with `DEV=true` (see [DEV configuration](../../README.md#dev-configuration)). Each
 listed service's own `docs/` folder is mounted read-only from its `_dev` volume at `/docs/<service>`, and served
-together at the site root - the git-tracked files themselves are never touched.
-
-By default it serves the `backend` and `frontend` documentation.
+together at the site root.
 
 ## Enable additional features
 

--- a/services/docs/compose.yaml
+++ b/services/docs/compose.yaml
@@ -10,6 +10,8 @@ services:
       - ${PWD}/.github/mkdocs/:/config/github-mkdocs
       - ./entrypoints/serve.sh:/usr/local/bin/serve.sh
       - ./config/index.md:/docs/index.md
+      - ./config/external-links.md:/docs/external-links.md
+      - ${PWD}:/docs/scicatlive
       - type: volume
         source: ${BE_VERSION:-v4}_dev
         target: /docs/backend
@@ -25,7 +27,5 @@ services:
     restart: on-failure
     entrypoint: /usr/local/bin/serve.sh
     environment:
-      GITHUB_SERVER_URL: https://github.com
-      GITHUB_REPOSITORY: SciCatProject/scicatlive
       CONFIG_DIR: /config/github-mkdocs
       PYTHONDONTWRITEBYTECODE: 1

--- a/services/docs/config/external-links.md
+++ b/services/docs/config/external-links.md
@@ -1,0 +1,10 @@
+# External links
+
+Links inside a service's own docs that point outside its `docs/` folder - to a source file, another service's docs,
+or similar - are, in the official published SciCatLive documentation site, rewritten to point at that file's location
+in its own GitHub repository at the currently released tag, following the pattern `<repo_url>/blob/<tag>/<path>`.
+
+Locally, this site aggregates documentation from several independent repositories under one shared `docs_dir`, so
+there's no reliable way to know which upstream repository a given external link actually belongs to. Rather than
+guess, and risk pointing at the wrong repository entirely, every such link here brings you back to this page instead
+of a resolved path.

--- a/services/docs/config/index.md
+++ b/services/docs/config/index.md
@@ -7,28 +7,15 @@ It's only available when running with `DEV=true`: each service's documentation i
 own container has cloned its repository, so what you see here reflects whatever branch/commit is currently checked
 out in your local dev containers, not necessarily the latest released version.
 
-## Shared styling and configuration
+## Configuration and adding a service
 
-Every service's docs are rendered using the same MkDocs configuration, theme and plugins:
-
-- mkdocs.yaml: `./.github/mkdocs/mkdocs.yaml`
-- theme overrides: `./.github/mkdocs/overrides`
-- relative_to.py hook: `./.github/mkdocs/relative_to.py`
-- requirements.txt: `./.github/mkdocs/requirements.txt`
-
-These are the same files used to build the official published SciCatLive documentation site.
-
-## Adding or changing a service here
-
-Each service listed here is mounted explicitly, not discovered automatically: to add a new service, or change which
-one of an existing service's folders is served, edit the volume mounts in
-`services/docs/compose.yaml`
-adding a `subpath: docs` mount from that service's own `_dev` volume onto `/docs/<service>`.
+See the [docs README](scicatlive/services/docs/README.md) for the shared MkDocs configuration this site uses, and for
+how to add or change which service's documentation is served here.
 
 ## Caveats
 
 Because every service is rendered with this shared configuration rather than whatever tooling (if any) it uses
 upstream, the result can differ from how that service renders or publishes its own docs elsewhere - available
-plugins, Markdown extensions and styling all follow this repo's setup, not the upstream project's. Links between two
-services' docs, or to files outside a given service's `docs/` folder, may also not resolve, since each service's
-documentation is normally authored assuming it is the root of its own site.
+plugins, Markdown extensions and styling all follow this repo's setup, not the upstream project's. Each service's
+documentation is also normally authored assuming it is the root of its own site, which no longer holds once
+aggregated here.


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

Adds scicatlive own repo to the docs.localhost rendering, including a "external-link" redirect that explains how external links are built

## Changes

- adds scicatlive own repo to docs.localhost

### Changes checklist

#### Modified Service?

- [ ] Steps from [features](/README.md#features) in README checked

#### New Service?

- [ ] Steps from [new service (advanced)](/README.md#advanced) in README checked
