### PR TITLE
fix: avoid orphan finished files

### DIFF
--- a/entrypoints/chown_root.sh
+++ b/entrypoints/chown_root.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-[ -e ".finished" ] && exit 0
-
 chown -R root:root . || true

--- a/entrypoints/infinite_loop.sh
+++ b/entrypoints/infinite_loop.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-touch .finished
-
 while true; do sleep 600; done

--- a/entrypoints/merge_json.sh
+++ b/entrypoints/merge_json.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-[ -e ".finished" ] && exit 0
+MARKER=".finished-$(basename "$0")"
+[ -e "$MARKER" ] && exit 0
 
 apk update && apk add jq gettext || echo "apk not available"
 apt update && apt install -y jq gettext-base || echo "apt not available"
 
 jq -s 'reduce .[] as $item ({}; . * $item)' /config/*.json | envsubst \
     > "${CONFIG_DIR:-/usr/share/nginx/html/assets}"/"${CONFIG_FILE:-config.json}"
+
+touch "$MARKER"

--- a/entrypoints/npm_ci.sh
+++ b/entrypoints/npm_ci.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
-[ -e ".finished" ] && exit 0
+MARKER=".finished-$(basename "$0")"
+[ -e "$MARKER" ] && exit 0
 
 npm ci
+
+touch "$MARKER"

--- a/entrypoints/setup_git.sh
+++ b/entrypoints/setup_git.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-[ -e ".finished" ] && exit 0
+MARKER=".finished-$(basename "$0")"
+[ -e "$MARKER" ] && exit 0
 
 ls .git && exit 0
 
@@ -16,4 +17,5 @@ DEFAULT_BRANCH=$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')
 git reset --hard origin/"${TAG:-$DEFAULT_BRANCH}"
 git clean -fd
 
-echo ".finished" >> .git/info/exclude
+echo ".finished-*" >> .git/info/exclude
+touch "$MARKER"

--- a/services/backend/services/v3/entrypoints/merge_json.sh
+++ b/services/backend/services/v3/entrypoints/merge_json.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-[ -e ".finished" ] && exit 0
+MARKER=".finished-$(basename "$0")"
+[ -e "$MARKER" ] && exit 0
 
 for config in $(find /config -maxdepth 1 -type f -exec basename {} \; | cut -d '.' -f 1 | sort -u)
 do
@@ -8,3 +9,5 @@ do
     npx --yes node-jq@6.0.0 -s 'reduce .[] as $item ({}; . * $item)' /config/"${config}"*.json > /home/node/app/server/"${config}".json
     npx --yes envsub /home/node/app/server/"${config}".json
 done
+
+touch "$MARKER"


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

It lifts cenral finished file creation and avoids entrypoints polluting each other finished state 

## Fixes

<!-- Please provide a list of the issues fixed by this PR -->

- all entrypiints with the guard but in containers not runnning sleep_infinity.sh where rerunning even if they had the guard

### Changes checklist

#### Modified Service?

- [ ] Steps from [features](/README.md#features) in README checked

#### New Service?

- [ ] Steps from [new service (advanced)](/README.md#advanced) in README checked
