### PR TITLE
fix: kill backgrounded test server in v4 dev

### DIFF
--- a/services/backend/services/v4/entrypoints/tests.sh
+++ b/services/backend/services/v4/entrypoints/tests.sh
@@ -4,9 +4,11 @@
 ## avoiding to fill the RAM which makes them freeze
 npm run test -- --runInBand
 
+set -m
 npm run start:test &
 PID="${!}"
 sleep 30
 npm run test:api:mocha
 
-kill "${PID}"
+kill -- -"${PID}"
+wait "${PID}" 2>/dev/null


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

npm run start:test forked a child process that `kill "${PID}"` didn't reach, leaving it bound to port 3000 and causing the final `npm start` to fail with EADDRINUSE. Kill the whole process group instead.

## Fixes

<!-- Please provide a list of the issues fixed by this PR -->

- kill background process in v4 tests.sh

### Changes checklist

#### Modified Service?

- [ ] Steps from [features](/README.md#features) in README checked

#### New Service?

- [ ] Steps from [new service (advanced)](/README.md#advanced) in README checked
