### PR TITLE
chore: fix PR template links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,8 +29,8 @@ See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-
 
 #### Modified Service?
 
-- [ ] Steps from [features](../README.md#features) in README checked
+- [ ] Steps from [features](https://github.com/SciCatProject/scicatlive/blob/master/README.md#features) in README checked
 
 #### New Service?
 
-- [ ] Steps from [new service (advanced)](../README.md#advanced) in README checked
+- [ ] Steps from [new service (advanced)](https://github.com/SciCatProject/scicatlive/blob/master/README.md#advanced) in README checked

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,8 +29,8 @@ See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-
 
 #### Modified Service?
 
-- [ ] Steps from [features](/README.md#features) in README checked
+- [ ] Steps from [features](../README.md#features) in README checked
 
 #### New Service?
 
-- [ ] Steps from [new service (advanced)](/README.md#advanced) in README checked
+- [ ] Steps from [new service (advanced)](../README.md#advanced) in README checked

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,8 +29,11 @@ See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-
 
 #### Modified Service?
 
-- [ ] Steps from [features](https://github.com/SciCatProject/scicatlive/blob/master/README.md#features) in README checked
+- [ ] Steps from [features] in README checked
 
 #### New Service?
 
-- [ ] Steps from [new service (advanced)](https://github.com/SciCatProject/scicatlive/blob/master/README.md#advanced) in README checked
+- [ ] Steps from [new service (advanced)] in README checked
+
+[features]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#features
+[new service (advanced)]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#advanced


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

Fix PR template links that was returing 404 before

### Changes checklist

#### Modified Service?

- [ ] Steps from [features](https://github.com/SciCatProject/scicatlive/blob/master/README.md#features) in README checked

#### New Service?

- [ ] Steps from [new service (advanced)](https://github.com/SciCatProject/scicatlive/blob/master/README.md#advanced) in README checked
