### PR TITLE
fix: use sdk env var from be upstream

### DIFF
--- a/.github/compose.dev.test.yaml
+++ b/.github/compose.dev.test.yaml
@@ -1,7 +1,6 @@
 services:
   frontend:
     volumes:
-      - ./entrypoints/npm_install_sdk.sh:/tmp/${GENERATE_SDK:+../docker-entrypoints/}80.sh
       - ./entrypoints/npm_tests.sh:/docker-entrypoints/90.sh
   searchapi:
     volumes:

--- a/.github/compose.sdk.test.yaml
+++ b/.github/compose.sdk.test.yaml
@@ -1,0 +1,22 @@
+services:
+  frontend:
+    depends_on:
+      openapigenerator:
+        condition: service_healthy
+    volumes:
+      - ./entrypoints/npm_install_sdk.sh:/docker-entrypoints/80.sh
+    configs:
+      - source: frontend_verify_build_sh
+        target: /docker-entrypoints/90.sh
+        mode: 0555
+  backend:
+    command: npm start
+    healthcheck:
+      test: |
+        wget --spider -Y off 'http://127.0.0.1:3000/api/v3/publisheddata/count'
+
+configs:
+  frontend_verify_build_sh:
+    content: |
+      #!/bin/sh
+      npm run build

--- a/.github/workflows/compose_test.yaml
+++ b/.github/workflows/compose_test.yaml
@@ -188,8 +188,12 @@ jobs:
           export DEV=${{ matrix.DEV }}
           export DEV_BBACKUP=${DEV}
           export GENERATE_SDK=${{ matrix.GENERATE_SDK }}
-          docker compose --profile '*' \
-            -f compose.yaml ${DEV:+-f .github/compose.dev.test.yaml} \
+          DEV_OVERLAY=${GENERATE_SDK:+.github/compose.sdk.test.yaml}
+          DEV_OVERLAY=${DEV_OVERLAY:-.github/compose.dev.test.yaml}
+          PROFILE=${GENERATE_SDK:+none}
+          PROFILE=${PROFILE:-'*'}
+          docker compose --profile "$PROFILE" \
+            -f compose.yaml ${DEV:+-f "$DEV_OVERLAY"} \
             up --wait --wait-timeout 1200 \
             || {
               docker compose ps --status=exited --services \

--- a/services/backend/services/v4/compose.dev.yaml
+++ b/services/backend/services/v4/compose.dev.yaml
@@ -18,6 +18,7 @@ services:
     environment:
       MONGODB_URI: mongodb://mongodb:27017/dev-dacat-next
       DEV: ${BACKEND_DEV:+true}
+      SDK_PACKAGE_SWAGGER_HELPERS_DISABLED: true
     healthcheck:
       retries: 20
       interval: 1m

--- a/services/backend/services/v4/config/.dev.env
+++ b/services/backend/services/v4/config/.dev.env
@@ -1,3 +1,2 @@
 MONGODB_URI=mongodb://mongodb:27017/scicat-test-db
 OPENSEARCH_HOST=https://opensearch:9200
-SDK_PACKAGE_SWAGGER_HELPERS_DISABLED=true


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

The sdk generation failed because the [env var set by the upstream](https://github.com/SciCatProject/backend/blob/master/.github/workflows/release-and-publish-sdk.yml#L141C11-L141C47) was not always picked up when running npm start

It also simplifies SDK tests by only running ng build from the frontend. Also include openapi container dependency when running it

### Changes checklist

#### Modified Service?

- [ ] Steps from [features] in README checked

#### New Service?

- [ ] Steps from [new service (advanced)] in README checked

[features]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#features
[new service (advanced)]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#advanced
