### PR TITLE
chore: distinguish sdk gen failures from fe use

### DIFF
--- a/.github/compose.sdk.test.yaml
+++ b/.github/compose.sdk.test.yaml
@@ -6,6 +6,9 @@ services:
     volumes:
       - ./entrypoints/npm_install_sdk.sh:/docker-entrypoints/80.sh
     configs:
+      - source: frontend_prebuild_sh
+        target: /docker-entrypoints/70.sh
+        mode: 0555
       - source: frontend_verify_build_sh
         target: /docker-entrypoints/90.sh
         mode: 0555
@@ -16,7 +19,28 @@ services:
         wget --spider -Y off 'http://127.0.0.1:3000/api/v3/publisheddata/count'
 
 configs:
+  frontend_prebuild_sh:
+    content: |
+      #!/bin/sh
+      npm run build > /tmp/prebuild.log 2>&1
+      echo $? > /tmp/prebuild_exit
   frontend_verify_build_sh:
     content: |
       #!/bin/sh
-      npm run build
+      npm run build > /tmp/postbuild.log 2>&1
+      post=$?
+      pre=$$(cat /tmp/prebuild_exit 2>/dev/null || echo 1)
+
+      if [ "$$pre" -eq 0 ] && [ "$$post" -ne 0 ]; then
+        echo "SDK_CHECK_RESULT=sdk_incompatible"
+        cat /tmp/postbuild.log
+        exit 1
+      fi
+
+      if [ "$$post" -ne 0 ]; then
+        echo "SDK_CHECK_RESULT=unrelated_failure"
+        cat /tmp/prebuild.log
+        exit 1
+      fi
+
+      echo "SDK_CHECK_RESULT=ok"

--- a/.github/workflows/compose_test.yaml
+++ b/.github/workflows/compose_test.yaml
@@ -209,8 +209,8 @@ jobs:
           steps.docker_up.outcome == 'failure' &&
           matrix.GENERATE_SDK == 'generate_sdk'
         run: |
-          STATUS=$(docker compose ps --format '{{.Health}}' frontend)
-          [ "$STATUS" != "healthy" ] \
+          docker compose logs frontend \
+            | grep -q "SDK_CHECK_RESULT=sdk_incompatible" \
             && echo "sdk_error=true" >> "$GITHUB_OUTPUT"
       - name: Fail on non-SDK failure
         if: >-


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

Build the frontend twice: once against the pinned upstream SDK, then again after regenerating it from the live backend. The pinned version is already validated upstream, so if that first build fails it points to a broken generator/environment here, not a real backend/frontend incompatibility - only a pass-then-fail transition is a genuine SDK incompatibility. Pre-existing failures now hard-fail CI instead of being silently swallowed or mislabeled as sdk-failed.

### Changes checklist

#### Modified Service?

- [ ] Steps from [features] in README checked

#### New Service?

- [ ] Steps from [new service (advanced)] in README checked

[features]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#features
[new service (advanced)]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#advanced
