### PR TITLE
chore: store unison file in tmp

### DIFF
--- a/entrypoints/bidirectional_backup.sh
+++ b/entrypoints/bidirectional_backup.sh
@@ -2,7 +2,7 @@
 
 [ -z "$(ls -A /bbackup)" ] && cp -r "${WORKDIR}"/. /bbackup
 
-flock -n /bbackup/.unison \
+flock -n /tmp/unison.lock \
     unison "${WORKDIR}" /bbackup \
     -repeat watch -batch -auto \
     -prefer /bbackup &

--- a/entrypoints/setup_git.sh
+++ b/entrypoints/setup_git.sh
@@ -18,4 +18,5 @@ git reset --hard origin/"${TAG:-$DEFAULT_BRANCH}"
 git clean -fd
 
 echo ".finished-*" >> .git/info/exclude
+echo ".unison" >> .git/info/exclude
 touch "$MARKER"

--- a/entrypoints/setup_git.sh
+++ b/entrypoints/setup_git.sh
@@ -18,5 +18,4 @@ git reset --hard origin/"${TAG:-$DEFAULT_BRANCH}"
 git clean -fd
 
 echo ".finished-*" >> .git/info/exclude
-echo ".unison" >> .git/info/exclude
 touch "$MARKER"

--- a/services/docs/services/userdocs/entrypoints/clone_git.sh
+++ b/services/docs/services/userdocs/entrypoints/clone_git.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
 git clone "${GITHUB_REPO}" "${WORKDIR}" || true
+
+echo ".finished-*" >> .git/info/exclude
+echo ".unison" >> .git/info/exclude

--- a/services/docs/services/userdocs/entrypoints/clone_git.sh
+++ b/services/docs/services/userdocs/entrypoints/clone_git.sh
@@ -3,4 +3,3 @@
 git clone "${GITHUB_REPO}" "${WORKDIR}" || true
 
 echo ".finished-*" >> .git/info/exclude
-echo ".unison" >> .git/info/exclude


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

Store unison file in /tmp to avoid dirtying the git status

### Changes checklist

#### Modified Service?

- [ ] Steps from [features] in README checked

#### New Service?

- [ ] Steps from [new service (advanced)] in README checked

[features]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#features
[new service (advanced)]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#advanced
