### PR TITLE
fix: avoid prefixing true in fe bash sub

### DIFF
--- a/services/frontend/compose.base.yaml
+++ b/services/frontend/compose.base.yaml
@@ -11,11 +11,11 @@ services:
       - source: frontend_config_json
         target: /config/config.0.json
       - source: frontend_config_oidc_json
-        target: /config/${OIDC_ENABLED:-.}config.1.json
+        target: /config/config.1${OIDC_ENABLED:+.json}
       - source: frontend_config_ldap_json
-        target: /config/${LDAP_ENABLED:-.}config.2.json
+        target: /config/config.2${LDAP_ENABLED:+.json}
       - source: frontend_config_jobs_json
-        target: /config/${JOBS_ENABLED:-.}config.3.json
+        target: /config/config.3${JOBS_ENABLED:+.json}
     labels:
       - traefik.http.routers.frontend.rule=Host(`localhost`)
       # Adding a label for traefik to learn which port to look for a service on


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

Fixes a bug that gave files silly names prefixed with "true"

### Changes checklist

#### Modified Service?

- [ ] Steps from [features] in README checked

#### New Service?

- [ ] Steps from [new service (advanced)] in README checked

[features]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#features
[new service (advanced)]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#advanced
