### PR TITLE
chore: normalize compose before localhost replace

### DIFF
--- a/services/proxy/config/.env
+++ b/services/proxy/config/.env
@@ -2,7 +2,7 @@ TRAEFIK_API_INSECURE=true
 
 TRAEFIK_PROVIDERS_DOCKER=true
 TRAEFIK_PROVIDERS_DOCKER_CONSTRAINTS=Label(`com.docker.compose.project`, `${COMPOSE_PROJECT_NAME}`)
-TRAEFIK_PROVIDERS_DOCKER_DEFAULTRULE=Host(`{{ normalize .Name | replace "-${COMPOSE_PROJECT_NAME}" ".localhost" }}`)
+TRAEFIK_PROVIDERS_DOCKER_DEFAULTRULE=Host(`{{ normalize .Name | replace (print "-" (normalize "${COMPOSE_PROJECT_NAME}")) ".localhost" }}`)
 
 TRAEFIK_PROVIDERS_FILE_FILENAME=/config/traefik.yaml
 


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

Without this the replacement would not take place when the COMPOSE_PROJECT_NAME had underscores. That is because

the service backend -> docker appends the compose project (compose_backend) -> the normalize converst _ to - and the replace then does not find the match unless normalized as well 

### Changes checklist

#### Modified Service?

- [ ] Steps from [features] in README checked

#### New Service?

- [ ] Steps from [new service (advanced)] in README checked

[features]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#features
[new service (advanced)]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#advanced
