### PR TITLE
chore: avoid tracking .env to skip local git stash

### DIFF
--- a/.env
+++ b/.env
@@ -43,22 +43,3 @@
 ## run multiple SciCatLive stacks side by side on the same machine. Local development only, not meant for production.
 # TRAEFIK_HTTP_PORT=80
 # TRAEFIK_HTTPS_PORT=443
-
-## -----------------------------------------------------------------------------------------------------------------
-## Computed from the options above - not meant to be edited directly. Compose files read these `_`-prefixed vars
-## instead of the raw options above, so that e.g. BACKEND_DEV can be left unset and still fall back to DEV.
-## -----------------------------------------------------------------------------------------------------------------
-_BE_VERSION=${BE_VERSION:-v4}
-_BACKEND_DEV=${DEV:-${BACKEND_DEV:-}}
-_FRONTEND_DEV=${DEV:-${FRONTEND_DEV:-}}
-_LANDINGPAGE_DEV=${DEV:-${LANDINGPAGE_DEV:-}}
-_OAIPMH_DEV=${DEV:-${OAIPMH_DEV:-}}
-_SEARCHAPI_DEV=${DEV:-${SEARCHAPI_DEV:-}}
-_SCICATLIVE_DEV=${DEV:-${SCICATLIVE_DEV:-}}
-_USER_DOCS_DEV=${DEV:-${USER_DOCS_DEV:-}}
-_TRAEFIK_HTTP_PORT=${TRAEFIK_HTTP_PORT:-80}
-_TRAEFIK_HTTPS_PORT=${TRAEFIK_HTTPS_PORT:-443}
-_BACKEND_HTTPS_URL=${BACKEND_HTTPS_URL:-http://backend.localhost:${_TRAEFIK_HTTP_PORT}}
-_FRONTEND_HTTPS_URL=${FRONTEND_HTTPS_URL:-http://localhost:${_TRAEFIK_HTTP_PORT}}
-_KEYCLOAK_HTTPS_URL=${KEYCLOAK_HTTPS_URL:-http://keycloak.localhost:${_TRAEFIK_HTTP_PORT}}
-_DEV_AI_STATE=${DEV_AI_STATE:-/root/.claude}

--- a/.env.computed
+++ b/.env.computed
@@ -1,0 +1,26 @@
+## -----------------------------------------------------------------------------------------------------------------
+## Computed from the options in .env - not meant to be edited directly. Compose files read these `_`-prefixed vars
+## instead of the raw options in .env, so that e.g. BACKEND_DEV can be left unset and still fall back to DEV.
+##
+## This file is explicitly referenced via `env_file:` on each top-level `include:` entry in compose.yaml - it is not
+## auto-loaded by Compose, unlike .env. If you add a new computed var here, make sure the include entries that need
+## it list this file.
+## -----------------------------------------------------------------------------------------------------------------
+_BE_VERSION=${BE_VERSION:-v4}
+_BACKEND_DEV=${DEV:-${BACKEND_DEV:-}}
+_FRONTEND_DEV=${DEV:-${FRONTEND_DEV:-}}
+_LANDINGPAGE_DEV=${DEV:-${LANDINGPAGE_DEV:-}}
+_OAIPMH_DEV=${DEV:-${OAIPMH_DEV:-}}
+_SEARCHAPI_DEV=${DEV:-${SEARCHAPI_DEV:-}}
+_SCICATLIVE_DEV=${DEV:-${SCICATLIVE_DEV:-}}
+_USER_DOCS_DEV=${DEV:-${USER_DOCS_DEV:-}}
+_TRAEFIK_HTTP_PORT=${TRAEFIK_HTTP_PORT:-80}
+_TRAEFIK_HTTPS_PORT=${TRAEFIK_HTTPS_PORT:-443}
+_BACKEND_HTTPS_URL=${BACKEND_HTTPS_URL:-http://backend.localhost:${_TRAEFIK_HTTP_PORT}}
+_FRONTEND_HTTPS_URL=${FRONTEND_HTTPS_URL:-http://localhost:${_TRAEFIK_HTTP_PORT}}
+_KEYCLOAK_HTTPS_URL=${KEYCLOAK_HTTPS_URL:-http://keycloak.localhost:${_TRAEFIK_HTTP_PORT}}
+_DEV_AI_STATE=${DEV_AI_STATE:-/root/.claude}
+## Computed - true whenever _BACKEND_DEV, _FRONTEND_DEV, _SCICATLIVE_DEV or _USER_DOCS_DEV (computed in the root .env)
+## is set, so compose.base.yaml (and therefore the docs service) is only pulled in when at least one mount would
+## actually be enabled.
+_DOCS_DEV=${_BACKEND_DEV:-${_FRONTEND_DEV:-${_SCICATLIVE_DEV:-${_USER_DOCS_DEV:-}}}}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 bbackup/*
 !.github/semantic-release/package.json
 !.github/markdownlint/package.json
+.env

--- a/README.md
+++ b/README.md
@@ -268,13 +268,33 @@ After optionally setting any configuration option, one can still select the serv
 Some of the env variables above have a default value that is computed from another one - for example `BACKEND_DEV`
 should also be enabled whenever `DEV=true`, and `BACKEND_HTTPS_URL` falls back to Traefik's local routing
 (`http://backend.localhost`) when left unset. Rather than duplicating that resolution logic at every place a compose
-file needs the final value, it is computed once, in a dedicated section at the bottom of [.env](./.env), into a
-`_`-prefixed variable of the same name (e.g. `_BACKEND_DEV`, `_BACKEND_HTTPS_URL`). Compose files read the
-`_`-prefixed variable, never the plain one.
+file needs the final value, it is computed once, in [.env.computed](./.env.computed), into a `_`-prefixed variable of
+the same name (e.g. `_BACKEND_DEV`, `_BACKEND_HTTPS_URL`). Compose files read the `_`-prefixed variable, never the
+plain one.
 
 These `_`-prefixed variables are **computed automatically and must not be edited directly** - to change a value, set
 the plain variable above it instead (e.g. `BACKEND_DEV=true`, not `_BACKEND_DEV=true`); leaving the plain variable
 unset/commented keeps the documented default.
+
+Unlike [.env](./.env), [.env.computed](./.env.computed) is **not** auto-loaded by `docker compose` - Compose only
+auto-loads a file literally named `.env`, so `.env.computed` only takes effect where explicitly referenced via
+`env_file:`. This is why every entry in the top-level [compose.yaml](compose.yaml) `include:` list repeats
+`env_file: [.env.computed]`. When
+[adding a new top-level service](#add-a-new-service), add it to this list too, or its compose files won't be able to
+resolve any `_`-prefixed variable they reference.
+
+If a variable is only needed to *gate which path an `include:` entry resolves to* (rather than being real
+per-service data), the simplest approach is to compute it as another `_`-prefixed variable directly in
+[.env.computed](./.env.computed), the same way `_BACKEND_DEV` is - see `_DOCS_DEV`, which decides whether
+[services/docs/compose.yaml](./services/docs/compose.yaml)'s first `include:` path is enabled, computed from whether
+any DEV-mode variant is set. This avoids needing a separate `.env` file just to hold one gating expression.
+
+Some services do need real local, non-computed data of their own (e.g. [services/frontend/.env](./services/frontend/.env)'s
+`APP`/`DEV_PORT`/`GITHUB_REPO`). Because Compose does not share `env_file` scope across sibling entries, this must be
+wired in as an explicit `env_file:` somewhere along the chain that reaches it. In this repo, that's done on the
+service's own nested `include:` entry (e.g. [services/frontend/compose.yaml](./services/frontend/compose.yaml)) rather
+than at the top-level entry in [compose.yaml](compose.yaml), which only lists `.env.computed`. Two rules matter if you
+do the same for a new service.
 
 #### DEV configuration
 
@@ -526,7 +546,9 @@ To add a new service (see the [jupyter service](./services/jupyter/) for a minim
 3. create the `compose.yaml` file
 4. eventually, add a `README.md` file in the service
 5. eventually, add the platform field, as described by the [supperted OSs](#supported-os-architectures)
-6. include the reference to (3) to the global [compose include list](compose.yaml) \*
+6. include the reference to (3) to the global [compose include list](compose.yaml) \*, with
+   `env_file: [.env.computed]` so it can resolve `_`-prefixed variables - see
+   [Computed environment variables](#computed-environment-variables)
 7. eventually, update the main [README.md](README.md)
 
 \* if the service to add is not shared globally, but specific to one particular service or another implementation of the
@@ -607,6 +629,9 @@ feature
    7. if the ENV's default should fall back to another variable (e.g. to `DEV`, or to a `localhost` URL), compute it
       once as a `_`-prefixed variable instead of duplicating the fallback at each usage site - see
       [Computed environment variables](#computed-environment-variables)
+   8. if the service needs its own local, non-computed `.env` (e.g. `APP`, `DEV_PORT`, `GITHUB_REPO`), add
+      `env_file:` to its own `include:` entry so it's actually loaded - see
+      [Computed environment variables](#computed-environment-variables) for the rules on where that's safe to do
 
 4. eventually, add entrypoints for init logics, as described by the section to
    [enable entrypoints](#if-the-service-does-not-support-entrypoints-yet-one-needs-to), e.g. like

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,12 +1,28 @@
 include:
-  - services/backend/compose.yaml
-  - services/frontend/compose.yaml
-  - services/searchapi/compose.yaml
-  - services/proxy/compose.yaml
-  - services/jupyter/compose.yaml
-  - services/landingpage/compose.yaml
-  - services/oaipmh/compose.yaml
-  - services/docs/compose.yaml
+  - path: services/backend/compose.yaml
+    env_file:
+      - .env.computed
+  - path: services/frontend/compose.yaml
+    env_file:
+      - .env.computed
+  - path: services/searchapi/compose.yaml
+    env_file:
+      - .env.computed
+  - path: services/proxy/compose.yaml
+    env_file:
+      - .env.computed
+  - path: services/jupyter/compose.yaml
+    env_file:
+      - .env.computed
+  - path: services/landingpage/compose.yaml
+    env_file:
+      - .env.computed
+  - path: services/oaipmh/compose.yaml
+    env_file:
+      - .env.computed
+  - path: services/docs/compose.yaml
+    env_file:
+      - .env.computed
 
 configs:
   entrypoints_loop_entrypoints_sh:

--- a/services/backend/compose.yaml
+++ b/services/backend/compose.yaml
@@ -6,6 +6,9 @@ include:
       - .${OIDC_ENABLED:+/services/${_BE_VERSION}/}compose.oidc.yaml
       - .${_BACKEND_DEV:+/services/${_BE_VERSION}/}compose.dev.yaml
       - .${JOBS_ENABLED:+/services/${_BE_VERSION}/}compose.jobs.yaml
+    env_file:
+      - .env
+      - services/${_BE_VERSION}/.env
 
 volumes:
   openapigenerator:

--- a/services/docs/.env
+++ b/services/docs/.env
@@ -1,4 +1,0 @@
-## Computed - true whenever _BACKEND_DEV, _FRONTEND_DEV, _SCICATLIVE_DEV or _USER_DOCS_DEV (computed in the root .env)
-## is set, so compose.base.yaml (and therefore the docs service) is only pulled in when at least one mount would
-## actually be enabled.
-_DOCS_DEV=${_BACKEND_DEV:-${_FRONTEND_DEV:-${_SCICATLIVE_DEV:-${_USER_DOCS_DEV:-}}}}

--- a/services/docs/README.md
+++ b/services/docs/README.md
@@ -41,9 +41,10 @@ Each mount is gated independently, following the same pattern:
 2. symlink `.compose.<service>.yaml` to [../.empty.yaml](../.empty.yaml), used when the service isn't enabled
 3. add `.${_<SERVICE>_DEV:+/}compose.<service>.yaml` to the `path:` list under `include:` in
    [compose.yaml](./compose.yaml)
-4. add `# <SERVICE>_DEV=true` and `_<SERVICE>_DEV=${DEV:-${<SERVICE>_DEV:-}}` to the root [.env](../../.env), so
-   `DEV=true` also enables it - see [Computed environment variables](../../README.md#computed-environment-variables)
-5. add `_<SERVICE>_DEV` to the `_DOCS_DEV` fallback chain in [.env](./.env), so
+4. add `# <SERVICE>_DEV=true` to the root [.env](../../.env), and `_<SERVICE>_DEV=${DEV:-${<SERVICE>_DEV:-}}` to
+   [.env.computed](../../.env.computed), so `DEV=true` also enables it - see
+   [Computed environment variables](../../README.md#computed-environment-variables)
+5. add `_<SERVICE>_DEV` to the `_DOCS_DEV` fallback chain in [.env.computed](../../.env.computed), so
    [compose.base.yaml](./compose.base.yaml) - and the docs service itself - gets pulled in once this flag alone is
    set
 

--- a/services/frontend/compose.yaml
+++ b/services/frontend/compose.yaml
@@ -3,3 +3,4 @@ include:
       - compose.base.yaml
       - compose.${_BE_VERSION}.yaml
       - .${_FRONTEND_DEV:+/}compose.dev.yaml
+    env_file: .env

--- a/services/landingpage/compose.yaml
+++ b/services/landingpage/compose.yaml
@@ -2,3 +2,4 @@ include:
   - path:
       - compose.base.yaml
       - .${_LANDINGPAGE_DEV:+/}compose.dev.yaml
+    env_file: .env

--- a/services/oaipmh/compose.yaml
+++ b/services/oaipmh/compose.yaml
@@ -2,3 +2,4 @@ include:
   - path:
       - compose.base.yaml
       - .${_OAIPMH_DEV:+/}compose.dev.yaml
+    env_file: .env

--- a/services/proxy/compose.yaml
+++ b/services/proxy/compose.yaml
@@ -20,6 +20,7 @@ services:
       - ./config/.env
       - ./config/.tls.env
       - ${PWD}/.env
+      - ${PWD}/.env.computed
     labels:
       - traefik.http.services.proxy.loadbalancer.server.port=8080
     restart: on-failure

--- a/services/searchapi/compose.yaml
+++ b/services/searchapi/compose.yaml
@@ -3,3 +3,4 @@ include:
       - compose.base.yaml
       - compose.${_BE_VERSION}.yaml
       - .${_SEARCHAPI_DEV:+/}compose.dev.yaml
+    env_file: .env


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

# Description

This allows developers when in DEV mode to have a clean git status since config changes in .env are not tracked. To force commit `git add -f .env`

### Changes checklist

#### Modified Service?

- [ ] Steps from [features] in README checked

#### New Service?

- [ ] Steps from [new service (advanced)] in README checked

[features]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#features
[new service (advanced)]: https://github.com/SciCatProject/scicatlive/blob/master/README.md#advanced
